### PR TITLE
Make Point and Dimension distinct type

### DIFF
--- a/include/seismic-cloud/seismic-cloud.hpp
+++ b/include/seismic-cloud/seismic-cloud.hpp
@@ -3,31 +3,46 @@
 
 namespace sc {
 
-struct point {
+struct ijk {
+    ijk() = default;
+
+    ijk(std::size_t x, std::size_t y, std::size_t z) :
+        x(x), y(y), z(z) {}
+
     std::size_t x;
     std::size_t y;
     std::size_t z;
 
-    bool operator < (const point& rhs) const noexcept (true) {
+    bool operator < (const ijk& rhs) const noexcept (true) {
         if (this->x < rhs.x) return true;
         if (this->y < rhs.y) return true;
         if (this->z < rhs.z) return true;
         return false;
     }
 
-    bool operator == (const point& rhs) const noexcept (true) {
+    bool operator == (const ijk& rhs) const noexcept (true) {
         return this->x == rhs.x
            and this->y == rhs.y
            and this->z == rhs.z;
     }
 };
 
+struct dimension : public ijk {
+    using ijk::ijk;
+    using ijk::operator ==;
+    using ijk::operator <;
+};
+
+struct point : public ijk {
+    using ijk::ijk;
+    using ijk::operator ==;
+    using ijk::operator <;
+};
+
 std::ostream& operator << (std::ostream& o, const point& rhs) {
     o << "(" << rhs.x << ", " << rhs.y << ", " << rhs.z << ")";
     return o;
 }
-
-using dimension = point;
 
 point global_to_local( point global, dimension fragment_size ) {
     return {

--- a/src/shatter.cpp
+++ b/src/shatter.cpp
@@ -112,13 +112,13 @@ int main( int args, char** argv ) {
     const auto crosslinecount = cube.crosslinecount();
     const auto samplecount    = cube.samplecount();
 
-    sc::dimension num_fragments {
-        int( std::ceil( double(inlinecount)    / cfg.xs ) ),
-        int( std::ceil( double(crosslinecount) / cfg.ys ) ),
-        int( std::ceil( double(samplecount)    / cfg.zs ) ),
+    auto num_fragments = sc::dimension {
+        std::size_t( std::ceil( double(inlinecount)    / cfg.xs ) ),
+        std::size_t( std::ceil( double(crosslinecount) / cfg.ys ) ),
+        std::size_t( std::ceil( double(samplecount)    / cfg.zs ) ),
     };
 
-    auto corners = cartesian( num_fragments, { cfg.xs, cfg.ys } );
+    auto corners = cartesian( num_fragments, { cfg.xs, cfg.ys, 0 } );
 
     for (const auto& corner : corners) {
         const auto max_x = corner.first  + cfg.xs;

--- a/src/stitch.cpp
+++ b/src/stitch.cpp
@@ -50,8 +50,8 @@ void throw_errno() {
     throw std::system_error( std::make_error_code( errc ) );
 }
 
-std::map< sc::point, std::vector< int > > bin( sc::point fragment_size,
-                                               sc::point cube_size,
+std::map< sc::point, std::vector< int > > bin( sc::dimension fragment_size,
+                                               sc::dimension cube_size,
                                                const std::vector< sc::point >& xs ) {
     std::map< sc::point, std::vector< int > > ret;
     for (const auto& p : xs) {
@@ -94,13 +94,13 @@ int main( int args, char** argv ) {
     json manifest;
     std::ifstream( cfg.input_dir + "/" + cfg.manifest ) >> manifest;
 
-    sc::point fragment_size {
+    sc::dimension fragment_size {
         manifest["fragment-xs"].get< int >(),
         manifest["fragment-ys"].get< int >(),
         manifest["fragment-zs"].get< int >(),
     };
 
-    sc::point cube_size {
+    sc::dimension cube_size {
         manifest["cube-xs"].get< int >(),
         manifest["cube-ys"].get< int >(),
         manifest["cube-zs"].get< int >(),

--- a/tests/generators.hpp
+++ b/tests/generators.hpp
@@ -2,16 +2,17 @@
 
 #include <catch/catch.hpp>
 
-struct PointGenerator : Catch::Generators::IGenerator< sc::point > {
+template < typename T >
+struct IjkGenerator : Catch::Generators::IGenerator< T > {
 
     std::minstd_rand m_rand;
     std::uniform_int_distribution< std::size_t > x_range;
     std::uniform_int_distribution< std::size_t > y_range;
     std::uniform_int_distribution< std::size_t > z_range;
 
-    sc::point p;
+    T p;
 
-    PointGenerator():
+    IjkGenerator():
         m_rand( std::random_device{}() ),
         x_range(),
         y_range(),
@@ -20,9 +21,7 @@ struct PointGenerator : Catch::Generators::IGenerator< sc::point > {
         next();
     }
 
-    PointGenerator( std::size_t x_max,
-                    std::size_t y_max,
-                    std::size_t z_max ):
+    IjkGenerator(std::size_t x_max, std::size_t y_max, std::size_t z_max) :
         m_rand( std::random_device{}() ),
         x_range( 0, x_max ),
         y_range( 0, y_max ),
@@ -36,33 +35,35 @@ struct PointGenerator : Catch::Generators::IGenerator< sc::point > {
         return true;
     }
 
-    sc::point const& get() const {
+    T const& get() const {
         return p;
     }
 };
 
+using PointGenerator = IjkGenerator< sc::point >;
 using PointGeneratorWrapper = Catch::Generators::GeneratorWrapper< sc::point >;
 
 PointGeneratorWrapper random_points() {
-  using Catch::Generators::IGenerator;
-  return PointGeneratorWrapper( std::make_unique< PointGenerator >() );
+    return PointGeneratorWrapper(std::make_unique< PointGenerator >());
 }
 
 PointGeneratorWrapper random_points( std::size_t x_max,
                                      std::size_t y_max,
                                      std::size_t z_max ) {
-    using Catch::Generators::IGenerator;
-    return PointGeneratorWrapper(std::make_unique< PointGenerator >( x_max,
-                                                                     y_max,
-                                                                     z_max ));
+    auto gen = std::make_unique< PointGenerator >(x_max, y_max, z_max);
+    return PointGeneratorWrapper(std::move(gen));
 }
 
-PointGeneratorWrapper random_dimensions() {
-    return random_points();
+using DimensionGenerator = IjkGenerator< sc::dimension >;
+using DimensionGeneratorWrapper = Catch::Generators::GeneratorWrapper< sc::dimension >;
+
+DimensionGeneratorWrapper random_dimensions() {
+    return DimensionGeneratorWrapper(std::make_unique< DimensionGenerator >());
 }
 
-PointGeneratorWrapper random_dimensions( std::size_t x_max,
-                                         std::size_t y_max,
-                                         std::size_t z_max ) {
-    return random_points( x_max, y_max, z_max );
+DimensionGeneratorWrapper random_dimensions(std::size_t x_max,
+                                            std::size_t y_max,
+                                            std::size_t z_max) {
+    auto gen = std::make_unique< DimensionGenerator >(x_max, y_max, z_max);
+    return DimensionGeneratorWrapper(std::move(gen));
 }


### PR DESCRIPTION
While very similar, both these points are semantic differences built on
top of an ijk triple. When they were just an alias they could be
interchanged without the compiler ever warning, but since they're now
properly disticint types this error source goes away.

In fact, the immediate effect is that a lot of code didn't compile
anymore, because the signature or arguments were inconsistent.

The property test generators too assumed that point and dimension were
the same type - these are now implemeted as two distinct generators.