### PR TITLE
Update the scan/segmenter tests to new version

### DIFF
--- a/core/ingestion/scan/scan/scan.py
+++ b/core/ingestion/scan/scan/scan.py
@@ -43,7 +43,7 @@ class parseint:
         return int.from_bytes(chunk, byteorder = self.endian, signed = True)
 
 def scan_binary(stream, endian):
-    """ Read OpenVDS info from the binary header
+    """ Read info from the binary header
 
     Read the necessary information from the binary header, and, if necessary,
     seek past the extended textual headers.
@@ -57,8 +57,8 @@ def scan_binary(stream, endian):
     Returns
     -------
     out : dict
-        dict of the OpenVDS keys dataSampleFormatCode, sampleCount, and
-        sampleInterval
+        dict of the keys format, samples, sampleinterval and
+        byteoffset-first-trace
 
     Notes
     -----
@@ -143,7 +143,7 @@ def resolve_endianness(big, little):
         return 'big'
 
     if big and not little:
-        return 'little'
+        return 'big'
 
     if little and not big:
         return 'little'
@@ -186,9 +186,6 @@ def scan(args, stream):
 
     Scan a stream, and produce an index for building a job schedule in further
     ingestion.
-
-    The output is compatible with what openvds' SEGYScan outputs, except the
-    persistentID does not describe the run, but rather the input file (sha256).
 
     Parameters
     ----------

--- a/core/ingestion/scan/scan/tests/test_binary_header.py
+++ b/core/ingestion/scan/scan/tests/test_binary_header.py
@@ -61,7 +61,7 @@ def test_supported_formats(textbin, endian, fmt):
     textbin.seek(3200)
 
     out = scan_binary(textbin, endian = endian)
-    assert out['dataSampleFormatCode'] == fmt[1]
+    assert out['format'] == fmt[1]
 
 @pytest.mark.parametrize('endian', ['big', 'little'])
 @given(integers(min_value = 0, max_value = math.pow(2, 15) - 1))
@@ -83,7 +83,7 @@ def test_get_sample_count(textbin, endian, val):
     textbin.seek(3200)
 
     out = scan_binary(textbin, endian = endian)
-    assert out['sampleCount'] == val
+    assert out['samples'] == val
 
 @pytest.mark.parametrize('endian', ['big', 'little'])
 @given(integers(min_value = 0, max_value = math.pow(2, 15) - 1))
@@ -105,4 +105,4 @@ def test_get_sample_interval(textbin, endian, val):
     textbin.seek(3200)
 
     out = scan_binary(textbin, endian = endian)
-    assert out['sampleInterval'] == val
+    assert out['sampleinterval'] == val

--- a/core/ingestion/scan/scan/tests/test_main.py
+++ b/core/ingestion/scan/scan/tests/test_main.py
@@ -3,6 +3,55 @@ import json
 
 from ..__main__ import main
 
+expected = {
+    'byteorder': 'big',
+    'format': 1,
+    'samples': 50,
+    'sampleinterval': 4.0,
+    'byteoffset-first-trace': 3600,
+    'guid': 'e939ed45a8258f1fbaf3c21ca83f54369c4c4def79384b4cb0fc069a4eb1a191',
+    'dimensions': [[1, 2, 3, 4, 5],
+                   [20, 21, 22, 23, 24],
+                   [0.0, 4.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 36.0,
+                    40.0, 44.0, 48.0, 52.0, 56.0, 60.0, 64.0, 68.0, 72.0, 76.0,
+                    80.0, 84.0, 88.0, 92.0, 96.0, 100.0, 104.0, 108.0, 112.0,
+                    116.0, 120.0, 124.0, 128.0, 132.0, 136.0, 140.0, 144.0,
+                    148.0, 152.0, 156.0, 160.0, 164.0, 168.0, 172.0, 176.0,
+                    180.0, 184.0, 188.0, 192.0, 196.0]
+                   ]
+}
+
+expected_lsb = expected.copy()
+expected_lsb.update({
+    'byteorder' : 'little',
+    'guid': 'f93a0b5102b1891039badf432e92f53df2f30218340617453c5dc23024521973'
+})
+
+expected_il5_xl21 = expected.copy()
+expected_il5_xl21.update({
+    'guid': 'f53a4af4ffa57e1e00b47f1a07ad31263f345cfae44a43a356b9ca0650eae41a'
+})
+
+expected_il5_xl21_lsb = expected.copy()
+expected_il5_xl21_lsb.update({
+    'byteorder' : 'little',
+    'guid': '1fedca281874fb195031669019ba7c430c6a3695cf3e48dd92dd28b833150cc9'
+})
+
+expected_2byte_keys = expected.copy()
+expected_2byte_keys.update({
+    'guid': 'ce39724dee2eac8038148f8823c008382815f0c2cf27be055861c226039568ad',
+    'dimensions': expected['dimensions'].copy()
+})
+
+expected_missing_line_numbers = expected.copy()
+expected_missing_line_numbers.update({
+    'guid': 'b8aa885d4c3524f3651083a0a27433135f41bf4e1db53a7acdb2548e0d8d6c2c',
+    'dimensions': expected['dimensions'].copy()
+})
+expected_missing_line_numbers['dimensions'][0] = [1, 2, 3, 5, 6]
+expected_missing_line_numbers['dimensions'][1] = [20, 21, 23, 24, 25]
+
 def datadir(filename):
     root = os.path.dirname(__file__)
     data = os.path.join(root, 'data')
@@ -11,26 +60,20 @@ def datadir(filename):
 def test_small_little_endian():
     s = main(['--little-endian', datadir('small-lsb.sgy')])
     run = json.loads(s)
-    with open(datadir('small-lsb.json')) as f:
-        ref = json.load(f)
 
-    assert run == ref
+    assert run == expected_lsb
 
 def test_small_big_endian():
     s = main(['--big-endian', datadir('small.sgy')])
     run = json.loads(s)
-    with open(datadir('small.json')) as f:
-        ref = json.load(f)
 
-    assert run == ref
+    assert run == expected
 
 def test_small_big_endian_default():
     s = main([datadir('small.sgy')])
     run = json.loads(s)
-    with open(datadir('small.json')) as f:
-        ref = json.load(f)
 
-    assert run == ref
+    assert run == expected
 
 def test_small_pretty_does_not_break_output():
     ugly = main([datadir('small.sgy')])
@@ -48,10 +91,8 @@ def test_small_big_endian_custom_inline_crossline_offset():
         datadir('small-iline-5-xline-21.sgy'),
     ])
     run = json.loads(s)
-    with open(datadir('small-iline-5-xline-21.json')) as f:
-        ref = json.load(f)
 
-    assert run == ref
+    assert run == expected_il5_xl21
 
 def test_small_little_endian_custom_inline_crossline_offset():
     s = main([
@@ -61,10 +102,8 @@ def test_small_little_endian_custom_inline_crossline_offset():
         datadir('small-iline-5-xline-21-lsb.sgy'),
     ])
     run = json.loads(s)
-    with open(datadir('small-iline-5-xline-21-lsb.json')) as f:
-        ref = json.load(f)
 
-    assert run == ref
+    assert run == expected_il5_xl21_lsb
 
 def test_2byte_primary_2byte_secondary():
     s = main([
@@ -74,15 +113,10 @@ def test_2byte_primary_2byte_secondary():
     ])
     result = json.loads(s)
 
-    assert result["primaryKey"] == [29, "TwoByte"]
-    assert result["secondaryKey"] == [71, "TwoByte"]
+    expected_2byte_keys['dimensions'][0] = [11, 12, 13, 14, 15]
+    expected_2byte_keys['dimensions'][1] = [30, 31, 32, 33, 34]
 
-    primaries = [k['primaryKey'] for k in result['segmentInfo']]
-    assert primaries == [11, 12, 13, 14, 15]
-
-    for s in result['segmentInfo']:
-        assert s['binInfoStart']['crosslineNumber'] == 30
-        assert s['binInfoStop']['crosslineNumber'] == 34
+    assert result == expected_2byte_keys
 
 def test_2byte_primary_4byte_secondary():
     s = main([
@@ -92,15 +126,10 @@ def test_2byte_primary_4byte_secondary():
     ])
     result = json.loads(s)
 
-    assert result["primaryKey"] == [29, "TwoByte"]
-    assert result["secondaryKey"] == [193, "FourByte"]
+    expected_2byte_keys['dimensions'][0] = [11, 12, 13, 14, 15]
+    expected_2byte_keys['dimensions'][1] = [20, 21, 22, 23, 24]
 
-    primaries = [k['primaryKey'] for k in result['segmentInfo']]
-    assert primaries == [11, 12, 13, 14, 15]
-
-    for s in result['segmentInfo']:
-        assert s['binInfoStart']['crosslineNumber'] == 20
-        assert s['binInfoStop']['crosslineNumber'] == 24
+    assert result == expected_2byte_keys
 
 def test_4byte_primary_2byte_secondary():
     s = main([
@@ -110,28 +139,13 @@ def test_4byte_primary_2byte_secondary():
     ])
     result = json.loads(s)
 
-    assert result["primaryKey"] == [189, "FourByte"]
-    assert result["secondaryKey"] == [71, "TwoByte"]
+    expected_2byte_keys['dimensions'][0] = [1, 2, 3, 4, 5]
+    expected_2byte_keys['dimensions'][1] = [30, 31, 32, 33, 34]
 
-    primaries = [k['primaryKey'] for k in result['segmentInfo']]
-    assert primaries == [1, 2, 3, 4, 5]
-
-    for s in result['segmentInfo']:
-        assert s['binInfoStart']['crosslineNumber'] == 30
-        assert s['binInfoStop']['crosslineNumber'] == 34
+    assert result == expected_2byte_keys
 
 def test_missing_line_numbers():
     s = main([datadir('missing-line-numbers.sgy')])
     result = json.loads(s)
 
-    primaries = [k['primaryKey'] for k in result['segmentInfo']]
-    assert primaries == [1, 2, 3, 5, 6]
-
-    for s in result['segmentInfo']:
-        assert s['binInfoStart']['crosslineNumber'] == 20
-        assert s['binInfoStop']['crosslineNumber'] == 25
-
-    with open(datadir('missing-line-numbers.json')) as f:
-        ref = json.load(f)
-
-    assert result == ref
+    assert result == expected_missing_line_numbers

--- a/core/ingestion/scan/scan/tests/test_segmenter.py
+++ b/core/ingestion/scan/scan/tests/test_segmenter.py
@@ -36,9 +36,5 @@ def test_regular_intervals(inlines, crosslines):
 
     for header in headers:
         seg.add(header)
-    seg.commit()
 
-    for segment in seg.segments:
-        fst = segment['traceStart']
-        lst = segment['traceStop']
-        assert lst - fst == crosslines - 1
+    assert len(seg.secondaries) == crosslines 

--- a/core/ingestion/scan/scan/tests/test_trace_header.py
+++ b/core/ingestion/scan/scan/tests/test_trace_header.py
@@ -37,36 +37,36 @@ def header():
 def test_sans_count_sans_interval(header, endian):
     head = header(endian)
     d = updated_count_interval(head, {}, endian)
-    assert d['sampleCount'] == 25
-    assert d['sampleInterval'] == 4000
+    assert d['samples'] == 25
+    assert d['sampleinterval'] == 4000
 
 @pytest.mark.parametrize('endian', ['little', 'big'])
 def test_with_count_sans_interval(header, endian):
     head = header(endian)
     prev = {
-        'sampleCount': 1,
+        'samples': 1,
     }
     d = updated_count_interval(head, prev, endian)
-    assert 'sampleCount' not in d
-    assert d['sampleInterval'] == 4000
+    assert 'samples' not in d
+    assert d['sampleinterval'] == 4000
 
 @pytest.mark.parametrize('endian', ['little', 'big'])
 def test_sans_count_with_interval(header, endian):
     head = header(endian)
     prev = {
-        'sampleInterval': 1,
+        'sampleinterval': 1,
     }
     d = updated_count_interval(head, prev, endian)
-    assert d['sampleCount'] == 25
-    assert 'sampleInterval' not in d
+    assert d['samples'] == 25
+    assert 'sampleinterval' not in d
 
 @pytest.mark.parametrize('endian', ['little', 'big'])
 def test_with_count_with_interval(header, endian):
     head = header(endian)
     prev = {
-        'sampleCount': 1,
-        'sampleInterval': 1,
+        'samples': 1,
+        'sampleinterval': 1,
     }
     d = updated_count_interval(head, prev, endian)
-    assert 'sampleCount' not in d
-    assert 'sampleInterval' not in d
+    assert 'samples' not in d
+    assert 'sampleinterval' not in d


### PR DESCRIPTION
The scan/segmenter was changed to no longer being compatible with
openvds. The tests were however still comparing against openvds output.