### PR TITLE
Upload first-dimension slice

### DIFF
--- a/core/ingestion/upload/upload/upload.py
+++ b/core/ingestion/upload/upload/upload.py
@@ -191,7 +191,6 @@ def upload(params, meta, segment, blob, f):
     }
     for x, y, z in tqdm.tqdm(xyz, **tqdm_opts):
         fname = '{}-{}-{}.f32'.format(x, y, z)
-        x = slice(x * fragment_dims[0], (x + 1) * fragment_dims[0])
         y = slice(y * fragment_dims[1], (y + 1) * fragment_dims[1])
         z = slice(z * fragment_dims[2], (z + 1) * fragment_dims[2])
         blob_name = '{}/{}'.format(basename, fname)
@@ -201,5 +200,5 @@ def upload(params, meta, segment, blob, f):
         blob.create_blob_from_bytes(
             container_name = container,
             blob_name = blob_name,
-            blob = bytes(dst[x, y, z]),
+            blob = bytes(dst[:, y, z]),
         )


### PR DESCRIPTION
The first dimension of the dst view of the source SEG-Y is already
indexed into, and doesn't vary with the x,y,z triple like the rest of
the loop. This is an oversight, but not detected immediately as blob
store is happy to accept empty files (and rightly so).

The first dimension should always be traversed fully.