### PR TITLE
Run apt-get update before install on az-pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ jobs:
           sudo make install -j2
         displayName: 'Build fmt'
       - script: |
+          sudo apt-get update
           sudo apt-get install -y libgnutls28-dev libcurl4-gnutls-dev
           sudo pip install scikit-build pybind11
           mkdir build


### PR DESCRIPTION
Snippet from a build log:
  Err:4 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libgnutls-openssl27 amd64 3.5.18-1ubuntu1.1
    404  Not Found [IP: 52.138.202.111 80]
  Err:5 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libgnutlsxx28 amd64 3.5.18-1ubuntu1.1
    404  Not Found [IP: 52.138.202.111 80]
  Err:7 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libgnutls-dane0 amd64 3.5.18-1ubuntu1.1
    404  Not Found [IP: 52.138.202.111 80]
  Err:12 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libgnutls28-dev amd64 3.5.18-1ubuntu1.1
    404  Not Found [IP: 52.138.202.111 80]
  Fetched 2099 kB in 0s (5886 kB/s)
  E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnutls28/libgnutls-openssl27_3.5.18-1ubuntu1.1_amd64.deb  404  Not Found [IP: 52.138.202.111 80]
  E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnutls28/libgnutlsxx28_3.5.18-1ubuntu1.1_amd64.deb  404  Not Found [IP: 52.138.202.111 80]
  E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnutls28/libgnutls-dane0_3.5.18-1ubuntu1.1_amd64.deb  404  Not Found [IP: 52.138.202.111 80]
  E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnutls28/libgnutls28-dev_3.5.18-1ubuntu1.1_amd64.deb  404  Not Found [IP: 52.138.202.111 80]
  E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?