### PR TITLE
Remove versioning from api binary

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,11 +17,10 @@ RUN protoc -I ../protos ../protos/core.proto --go_out=plugins=grpc:proto
 
 RUN go test -race ./...
 
-ARG VERSION
 RUN CGO_ENABLED=0\
     GOOS=linux\
     GOARCH=amd64 \
-    go build -ldflags="-w -s -X main.Version=${VERSION}"  -o /bin/sc-api
+    go build -ldflags="-w -s"  -o /bin/sc-api
 
 FROM scratch as deployer
 COPY --from=builder /bin/sc-api /bin/sc-api

--- a/api/cmd/root.go
+++ b/api/cmd/root.go
@@ -15,9 +15,8 @@ var rootCmd = &cobra.Command{
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
-func Execute(app, v string) {
+func Execute(app string) {
 	rootCmd.Use = app
-	rootCmd.Version = v
 
 	if err := rootCmd.Execute(); err != nil {
 		l.LogE("Executing command", err)

--- a/api/cmd/serve.go
+++ b/api/cmd/serve.go
@@ -72,7 +72,6 @@ func manifestStoreConfig() interface{} {
 
 func createHTTPServerOptions() ([]server.HTTPServerOption, error) {
 	opts := make([]server.HTTPServerOption, 0)
-	opts = append(opts, server.WithAPIVersion(config.Version()))
 
 	if config.UseAuth() {
 		authServer, err := config.AuthServer()

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -76,10 +76,6 @@ func SetDefault(key string, val interface{}) {
 	viper.SetDefault(key, val)
 }
 
-func Version() string {
-	return fmt.Sprintf("Seismic Cloud API %s", version)
-}
-
 func AuthServer() (*url.URL, error) {
 	s := viper.GetString("AUTHSERVER")
 	if len(s) == 0 {

--- a/api/config/version.go
+++ b/api/config/version.go
@@ -1,9 +1,0 @@
-package config
-
-var (
-	version string
-)
-
-func SetVersion(v string) {
-	version = v
-}

--- a/api/main.go
+++ b/api/main.go
@@ -3,24 +3,17 @@ package main
 import (
 	"fmt"
 	"log"
-	"runtime"
 
 	"github.com/equinor/seismic-cloud/api/cmd"
-	"github.com/equinor/seismic-cloud/api/config"
 	l "github.com/equinor/seismic-cloud/api/logger"
 	jww "github.com/spf13/jwalterweatherman"
 )
 
-var AppName string = "sc-api"
-var Version string
+var AppName = "sc-api"
 
 func init() {
-	Version += " " + runtime.Version()
-	config.SetVersion(Version)
-
 	jww.SetStdoutThreshold(jww.LevelFatal)
 	log.SetPrefix("[INFO] ")
-	l.Version = Version
 	l.AddLoggerSource("main.log", log.SetOutput)
 	l.AddLoggerSource("setup.log", jww.SetLogOutput)
 }
@@ -48,6 +41,6 @@ func main() {
 
 	}()
 
-	cmd.Execute(AppName, Version)
+	cmd.Execute(AppName)
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ services:
     build:
       context: .
       dockerfile: api/Dockerfile
-      args:
-        - VERSION
     ports:
       - '8080:8080'
     environment:

--- a/tests/integration/integration_tests.py
+++ b/tests/integration/integration_tests.py
@@ -33,12 +33,6 @@ def test_version_no_auth():
     assert r.status_code == 401
 
 
-def test_version():
-    r = requests.get(sc_uri, headers=auth_header)
-    assert r.status_code == 200
-    assert r.content.startswith(b"Seismic Cloud API ")
-
-
 def test_surface_list():
     r = requests.get(sc_uri+"/surface", headers=auth_header)
     assert r.status_code == 200


### PR DESCRIPTION
Enough to have the docker container versioned as the api binary will
probably always run inside docker
Edit:
Enough to have the docker container versioned for now