### PR TITLE
Add oneseismic.geometry python extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
       python: 3.7
     - language: python
       python: 3.6
-    - language: c++
-      dist: bionic
-      compiler: clang
 
 install:
   - sudo apt-get install -y libgnutls28-dev libcurl4-gnutls-dev
@@ -34,19 +31,16 @@ install:
   - popd
 
 script:
-    - if [[ -n "${TRAVIS_PYTHON_VERSION+1}" ]]; then
-        pushd core/ingestion/scan &&
-        pip install -r requirements-dev.txt &&
-        python setup.py test && popd;
-        pushd core/ingestion/upload &&
-        pip install -r requirements-dev.txt &&
-        python setup.py test && popd;
-      fi
+  - pushd core/ingestion/scan
+  - pip install -r requirements-dev.txt
+  - python setup.py test && popd
+  - pushd core/ingestion/upload 
+  - pip install -r requirements-dev.txt
+  - python setup.py test && popd
+  - pip install -r core/python/requirements-dev.txt
 
-    - if [[ -z $TRAVIS_PYTHON_VERSION ]]; then
-        mkdir build &&
-        pushd build &&
-        cmake ../core -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON &&
-        make &&
-        ctest --output-on-failure;
-      fi
+  - mkdir build
+  - pushd build
+  - cmake ../core -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DBUILD_PYTHON=ON
+  - make
+  - ctest --output-on-failure;

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,6 +6,7 @@ include(CTest)
 include(GNUInstallDirs)
 include(TestBigEndian)
 
+option(BUILD_PYTHON "Build Python library" ON)
 
 add_library(json INTERFACE)
 target_include_directories(json INTERFACE external/nlohmann)
@@ -112,6 +113,7 @@ export(
     NAMESPACE
         oneseismic::
 )
+set(ONESEISMIC_LIB_CMAKECONFIG_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "")
 
 add_subdirectory(external/catch2)
 
@@ -138,3 +140,5 @@ else ()
 endif()
 
 add_test(NAME test COMMAND tests)
+
+add_subdirectory(python)

--- a/core/include/oneseismic/geometry.hpp
+++ b/core/include/oneseismic/geometry.hpp
@@ -30,6 +30,9 @@ public:
     basic_tuple() noexcept (true) { this->fill(0); }
     basic_tuple(const base_type& t) noexcept (true) : base_type(t) {}
 
+    using reference  = typename base_type::reference;
+    using value_type = typename base_type::value_type;
+
     template < typename... Vs >
     basic_tuple(std::size_t v, Vs... vs) noexcept (true) :
     basic_tuple(base_type{ v, static_cast< std::size_t >(vs) ... }) {

--- a/core/python/CMakeLists.txt
+++ b/core/python/CMakeLists.txt
@@ -1,0 +1,86 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(oneseismic-python)
+
+if (NOT BUILD_PYTHON)
+    return()
+endif ()
+
+find_package(PythonInterp 3 REQUIRED)
+
+if (NOT PYTHON_EXECUTABLE)
+    message(WARNING "Could not find python - skipping python bindings")
+    message(WARNING "Select specific python distribution with "
+                    "-DPYTHON_EXECUTABLE=bin/python")
+    return()
+endif()
+
+set(setup.py ${CMAKE_CURRENT_SOURCE_DIR}/setup.py)
+
+if (CMAKE_BUILD_TYPE)
+    # use the cmake_build_type of the source project, unless it has been
+    # specifically overriden
+    set(ONESEISMIC_PYTHON_BUILD_TYPE
+        --build-type=${CMAKE_BUILD_TYPE}
+        CACHE STRING "override CMAKE_BUILD_TYPE in python extension"
+    )
+endif ()
+
+add_custom_target(oneseismic-python
+    ALL
+    COMMENT "Building python library with setup.py"
+    SOURCES ${setup.py}
+    VERBATIM
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	
+    COMMAND ${PYTHON_EXECUTABLE} ${setup.py}
+        # build the extension inplace (really, once its built, copy it to the
+        # source tree) so that post-build, the directory can be used to run
+        # tests against
+        build_ext --inplace
+        build # setup.py build args
+	    --cmake-executable ${CMAKE_COMMAND}
+	    --generator ${CMAKE_GENERATOR}
+	    ${ONESEISMIC_PYTHON_BUILD_TYPE}
+        -- # cmake to the extension
+	    -Doneseismic_DIR=${ONESEISMIC_LIB_CMAKECONFIG_DIR}
+            # "install" to the python/oneseismic dir with rpath, so there's no need
+            # to fiddle with environment in ctest to load the core library from
+            # the build tree
+	    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
+	    -DCMAKE_INSTALL_RPATH=$<TARGET_FILE_DIR:oneseismic::oneseismic>
+	    -DCMAKE_INSTALL_NAME_DIR=$<TARGET_FILE_DIR:oneseismic::oneseismic>
+)
+
+
+add_dependencies(oneseismic-python oneseismic::oneseismic)
+
+install(CODE "
+    if (DEFINED ENV{DESTDIR})
+        get_filename_component(abs-destdir \"\$ENV{DESTDIR}\" ABSOLUTE)
+        set(root_destdir --root \${abs-destdir})
+    endif()
+    execute_process(
+        COMMAND ${PYTHON_EXECUTABLE} ${setup.py}
+            install
+                \${root_destdir}
+                --cmake-executable \"${CMAKE_COMMAND}\"
+                --generator \"${CMAKE_GENERATOR}\"
+		${ONESEISMIC_PYTHON_BUILD_TYPE}
+            --
+                -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )"
+)
+
+# run tests with setup.py test
+# this is very slow compared to invoking pytest directly, but setuptools will
+# copy the built extension into the tree as it sees fit
+#
+# use --skip-cmake, otherwise running the tests would trigger a build with
+# different args to setup.py, rebuilding the python lib (and wrongly so as it
+# either won't find oneseismic or picked up on a system installed one)
+add_test(
+    NAME python.unit
+    COMMAND ${PYTHON_EXECUTABLE} ${setup.py} --skip-cmake test
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/core/python/oneseismic/CMakeLists.txt
+++ b/core/python/oneseismic/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(oneseismic-python-extension LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+set(CMAKE_C_VISIBILITY_PRESET   "hidden")
+
+find_package(PythonExtensions REQUIRED)
+find_package(oneseismic REQUIRED)
+find_package(fmt REQUIRED)
+find_package(Protobuf REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(zmq IMPORTED_TARGET REQUIRED libzmq)
+
+add_library(geometry MODULE geometry.cpp)
+target_include_directories(geometry
+    PRIVATE
+        ${PYBIND11_INCLUDE_DIRS}
+)
+python_extension_module(geometry)
+target_link_libraries(geometry oneseismic::oneseismic)
+
+if (MSVC)
+    target_compile_options(geometry
+        BEFORE
+        PRIVATE
+            /EHsc
+    )
+endif ()
+
+install(TARGETS geometry LIBRARY DESTINATION oneseismic)

--- a/core/python/oneseismic/geometry.cpp
+++ b/core/python/oneseismic/geometry.cpp
@@ -1,0 +1,45 @@
+#include <array>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <oneseismic/geometry.hpp>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(geometry, m) {
+
+    py::class_< one::CS< 3 > >(m, "CS3")
+      .def(py::init< const std::array< std::size_t, 3 >& >())
+      .def(py::init< std::size_t, std::size_t, std::size_t >())
+      .def("__getitem__", [](const one::CS< 3 >& cs, std::size_t i) {
+        if (i > 2)
+          throw py::index_error();
+        return cs[i];
+      }
+      )
+    ;
+ py::class_< one::FS< 3 > >(m, "FS3")
+     .def(py::init< const std::array< std::size_t, 3 >& >())
+     .def(py::init< std::size_t, std::size_t, std::size_t >())
+     .def(py::init< const one::FS< 3 >& >())
+     .def("__getitem__", [](const one::FS< 3 >& fs, std::size_t i) {
+       if (i > 2)
+         throw py::index_error();
+       return fs[i];
+     }
+     )
+   ;
+
+   py::class_< one::gvt< 3 > >(m, "GVT3")
+     .def(py::init< const one::CS< 3 >&, const one::FS< 3 >& >())
+     .def("fragment_shape", [](const one::gvt< 3 >& gvt){
+        return gvt.fragment_shape();
+      }
+     )
+     .def("fragment_count", [](const one::gvt< 3 >& gvt, std::size_t d) {
+        return gvt.fragment_count(one::dimension< 3 >(d));
+     }
+    )
+   ;
+}

--- a/core/python/oneseismic/tests/test_geometry.py
+++ b/core/python/oneseismic/tests/test_geometry.py
@@ -1,0 +1,62 @@
+import pytest
+
+import oneseismic.geometry as geo
+
+def test_valid_cube_shape():
+    cs = geo.CS3(64,64,64)
+    cs = geo.CS3([64,64,64])
+    cs = geo.CS3((64,64,64))
+    with pytest.raises(TypeError):
+        cs = geo.CS3(-64,64,64)
+        cs = geo.CS3([64,-64,64])
+        cs = geo.CS3((64,64,-64))
+
+def test_valid_fragment_shape():
+    fs = geo.FS3(8,8,8)
+    fs = geo.FS3([8,8,8])
+    fs = geo.FS3((8,8,8))
+    with pytest.raises(TypeError):
+        fs = geo.FS3(-8,8,8)
+        fs = geo.FS3([8,-8,8])
+        fs = geo.FS3((8,8,-8))
+
+def test_valid_gvt():
+    gvt = geo.GVT3(geo.CS3(64,64,64), geo.FS3(8,8,8))
+
+def test_valid_fragment_shape():
+    gvt = geo.GVT3(geo.CS3(9,15,23), geo.FS3(3,9,5))
+    assert gvt.fragment_shape()[0] == 3
+    assert gvt.fragment_shape()[1] == 9
+    assert gvt.fragment_shape()[2] == 5
+    with pytest.raises(IndexError):
+        assert gvt.fragment_shape()[3] == 6
+
+def test_gvt_fragment_count():
+    gvt = geo.GVT3(geo.CS3(9,15,23), geo.FS3(3,9,5))
+    assert gvt.fragment_count(0) == 3
+    assert gvt.fragment_count(1) == 2
+    assert gvt.fragment_count(2) == 5
+    with pytest.raises(ValueError):
+        assert gvt.fragment_count(3) == 0
+
+def dstshape(gvt):
+    dstshape = (
+        gvt.fragment_count(0) * gvt.fragment_shape()[0],
+        gvt.fragment_count(1) * gvt.fragment_shape()[1],
+        gvt.fragment_count(2) * gvt.fragment_shape()[2],
+    )
+    return dstshape
+
+def test_dstshape():
+
+    expected = (5,5,8)
+    gvt = geo.GVT3(geo.CS3(3,5,6), geo.FS3(5,5,4))
+    assert dstshape(gvt) == expected
+
+    expected = (16,8,16)
+    gvt = geo.GVT3(geo.CS3(14,5,13), geo.FS3(8,8,8))
+    assert dstshape(gvt) == expected
+
+    expected = (64,64,64)
+    gvt = geo.GVT3(geo.CS3(64,64,64), geo.FS3(8,8,8))
+    assert dstshape(gvt) == expected

--- a/core/python/requirements-dev.txt
+++ b/core/python/requirements-dev.txt
@@ -1,0 +1,4 @@
+scikit-build
+pybind11
+pytest
+pytest-runner

--- a/core/python/setup.cfg
+++ b/core/python/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test = pytest

--- a/core/python/setup.py
+++ b/core/python/setup.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import os
+import skbuild
+import setuptools
+
+class get_pybind_include(object):
+    def __init__(self, user=False):
+        self.user = user
+
+    def __str__(self):
+        # postpone importing pybind11 until building actually happens
+        import pybind11
+        return pybind11.get_include(self.user)
+
+def src(x):
+    root = os.path.dirname( __file__ )
+    return os.path.abspath(os.path.join(root, x))
+
+pybind_includes = [
+    str(get_pybind_include()),
+    str(get_pybind_include(user = True))
+]
+
+skbuild.setup(
+    name = 'oneseismic',
+    description = 'oneseismic',
+    long_description = 'oneseismic',
+    url = 'https://github.com/equinor/seismic-cloud',
+    packages = [
+        'oneseismic',
+    ],
+    license = 'AGPL-3.0',
+    platforms = 'any',
+    install_requires = [
+    ],
+    setup_requires = [
+        'setuptools >= 28',
+        'pybind11 >= 2.2',
+        'pytest-runner',
+    ],
+    tests_require = [
+        'pytest',
+    ],
+    # we're building with the pybind11 fetched from pip. Since we don't rely on
+    # a cmake-installed pybind there's also no find_package(pybind11) -
+    # instead, the get include dirs from the package and give directly from
+    # here
+    cmake_args = [
+        '-DPYBIND11_INCLUDE_DIRS=' + ';'.join(pybind_includes),
+        # we can safely pass OSX_DEPLOYMENT_TARGET as it's ignored on
+        # everything not OS X. We depend on C++11, which makes our minimum
+        # supported OS X release 10.9
+        '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9',
+    ],
+    cmake_source_dir = 'oneseismic',
+    # skbuild's test imples develop, which is pretty obnoxious instead, use a
+    # manually integrated pytest.
+    cmdclass = { 'test': setuptools.command.test.test },
+)


### PR DESCRIPTION
The bulk of this patch is the build system (setup.py and cmake), which
are largely taken from ecl3 [1]. The oneseismic.geometry exposes the 3D
CS, FS, and GVT datatypes, and virtually no operations.

[1] https://github.com/equinor/ecl3