### PR TITLE
Pass azure base url as argument

### DIFF
--- a/core/include/oneseismic/azure.hpp
+++ b/core/include/oneseismic/azure.hpp
@@ -15,7 +15,7 @@ inline constexpr const char* x_ms_version() noexcept (true) {
 
 class az : public one::storage_configuration {
 public:
-    az(std::string acc, std::string k);
+    az(std::string acc, std::string k, std::string base_url = "https://{}.blob.core.windows.net");
 
     std::string sign(
         const std::string& date,
@@ -56,6 +56,7 @@ public:
 private:
     std::string storage_account;
     std::string key;
+    std::string base_url;
 };
 
 }

--- a/core/src/azure.cpp
+++ b/core/src/azure.cpp
@@ -48,9 +48,10 @@ std::string x_ms_date() noexcept (false) {
     return fmt::format(fmtstr, *gmt);
 }
 
-az::az(std::string acc, std::string key) :
+az::az(std::string acc, std::string key, std::string base_url) :
     storage_account(std::move(acc)),
-    key(base64_decode(key))
+    key(base64_decode(key)),
+    base_url(std::move(base_url))
 {}
 
 std::string az::sign(
@@ -126,9 +127,10 @@ curl_slist* az::http_headers(
 }
 
 std::string az::url(const one::batch& batch, const std::string& id) const {
+    std::string base_url = fmt::format(this->base_url, batch.root);
     return fmt::format(
-        "https://{}.blob.core.windows.net/{}/{}/{}.f32",
-        batch.root,
+        "{}/{}/{}/{}.f32",
+	base_url,
         batch.guid,
         batch.fragment_shape,
         id

--- a/core/tests/azure-transfer-config.cpp
+++ b/core/tests/azure-transfer-config.cpp
@@ -27,6 +27,20 @@ TEST_CASE(
 }
 
 TEST_CASE(
+        "Configuration makes the correct URL with base URL passed as argument",
+        "[azure][az]") {
+    const auto expected =
+        "https://127.0.0.1:1000/guid/src/64-64-64/0-1-2.f32";
+
+    one::batch batch;
+    batch.guid = "guid";
+    batch.fragment_shape = "src/64-64-64";
+    one::az az("", "", "https://127.0.0.1:1000");
+    const auto url = az.url(batch, "0-1-2");
+    CHECK(url == expected);
+}
+
+TEST_CASE(
         "x-ms-date starts with x-ms-date",
         "[azure][az]") {
     CHECK_THAT(one::x_ms_date(), StartsWith("x-ms-date:"));


### PR DESCRIPTION
Storage configuration takes azure base url as argument, with
"https://{}.blob.core.windows.net" as default. A different base
url can then be used for testing with azurite.