### PR TITLE
Fix faulty test

### DIFF
--- a/core/tests/fragment-task.cpp
+++ b/core/tests/fragment-task.cpp
@@ -62,6 +62,11 @@ std::string make_slice_request(int dim, int idx) {
     fragment_shape->set_dim1(2);
     fragment_shape->set_dim2(2);
 
+    auto* cube_shape = req.mutable_cube_shape();
+    cube_shape->set_dim0(2);
+    cube_shape->set_dim1(2);
+    cube_shape->set_dim2(2);
+
     auto* slice = req.mutable_slice();
     slice->set_dim(dim);
     slice->set_idx(idx);
@@ -124,7 +129,7 @@ TEST_CASE("Fragment is sliced and pushed through", "[slice]") {
     CHECK(tiles.Get(0).layout().iterations()   == 2);
     CHECK(tiles.Get(0).layout().chunk_size()   == 2);
     CHECK(tiles.Get(0).layout().initial_skip() == 0);
-    CHECK(tiles.Get(0).layout().superstride()  == 0);
+    CHECK(tiles.Get(0).layout().superstride()  == 2);
     CHECK(tiles.Get(0).layout().substride()    == 2);
 
     CHECK(tiles.Get(0).v().size() == 4);


### PR DESCRIPTION
The test was not setting cube shape causing it to default to 0. This
does not affect the correctness of the test but it triggers an assertion
when compiled in Debug mode.