### PR TITLE
Remove unused storage_account member

### DIFF
--- a/core/include/oneseismic/azure.hpp
+++ b/core/include/oneseismic/azure.hpp
@@ -15,7 +15,7 @@ inline constexpr const char* x_ms_version() noexcept (true) {
 
 class az : public one::storage_configuration {
 public:
-    az(std::string acc, std::string k);
+    az(std::string k);
 
     std::string sign(
         const std::string& date,
@@ -54,7 +54,6 @@ public:
         override;
 
 private:
-    std::string storage_account;
     std::string key;
 };
 

--- a/core/src/azure.cpp
+++ b/core/src/azure.cpp
@@ -48,8 +48,7 @@ std::string x_ms_date() noexcept (false) {
     return fmt::format(fmtstr, *gmt);
 }
 
-az::az(std::string acc, std::string key) :
-    storage_account(std::move(acc)),
+az::az(std::string key) :
     key(base64_decode(key))
 {}
 

--- a/core/src/server-fragment.cpp
+++ b/core/src/server-fragment.cpp
@@ -15,7 +15,6 @@ int main(int argc, char** argv) {
     std::string sink_address;
     std::string control_address;
     std::string fail_address;
-    std::string acc;
     std::string key;
     bool help = false;
     int ntransfers = 4;
@@ -37,9 +36,6 @@ int main(int argc, char** argv) {
         | clara::Opt(ntransfers, "transfers")
             ["-j"]["--transfers"]
             (fmt::format("Concurrent blob connections, default = {}", ntransfers))
-        | clara::Opt(acc, "storage account")
-            ["-a"]["--account"]
-            ("Storage account")
         | clara::Opt(key, "key")
             ["-k"]["--key"]
             ("Pre-shared key")
@@ -57,10 +53,6 @@ int main(int argc, char** argv) {
         std::exit(EXIT_SUCCESS);
     }
 
-    if (acc.empty()) {
-        std::cerr << "Need storage account\n" << cli << "\n";
-        std::exit(EXIT_FAILURE);
-    }
 
     if (key.empty()) {
         std::cerr << "Need pre-shared key\n" << cli << "\n";
@@ -88,7 +80,7 @@ int main(int argc, char** argv) {
         std::exit(EXIT_FAILURE);
     }
 
-    one::az az(acc, key);
+    one::az az(key);
     one::transfer xfer(ntransfers, az);
     one::fragment_task task;
 

--- a/core/src/server-manifest.cpp
+++ b/core/src/server-manifest.cpp
@@ -80,7 +80,6 @@ int main(int argc, char** argv) {
     std::string sink_address = "tcp://*:68142";
     std::string control_address;
     std::string fail_address;
-    std::string acc;
     std::string key;
     bool help = false;
     int ntransfers = 4;
@@ -102,9 +101,6 @@ int main(int argc, char** argv) {
         | clara::Opt(ntransfers, "transfers")
             ["-j"]["--transfers"]
             (fmt::format("Concurrent blob connections, default = {}", ntransfers))
-        | clara::Opt(acc, "storage account")
-            ["-a"]["--account"]
-            ("Storage account")
         | clara::Opt(key, "key")
             ["-k"]["--key"]
             ("Pre-shared key")
@@ -122,10 +118,6 @@ int main(int argc, char** argv) {
         std::exit(EXIT_SUCCESS);
     }
 
-    if (acc.empty()) {
-        std::cerr << "Need storage account\n" << cli << "\n";
-        std::exit(EXIT_FAILURE);
-    }
 
     if (key.empty()) {
         std::cerr << "Need pre-shared key\n" << cli << "\n";
@@ -158,7 +150,7 @@ int main(int argc, char** argv) {
         std::exit(EXIT_FAILURE);
     }
 
-    one::az_manifest az(acc, key);
+    one::az_manifest az(key);
     one::transfer xfer(ntransfers, az);
     one::manifest_task task;
 

--- a/core/tests/azure-transfer-config.cpp
+++ b/core/tests/azure-transfer-config.cpp
@@ -21,7 +21,7 @@ TEST_CASE(
     batch.root = "acc";
     batch.guid = "guid";
     batch.fragment_shape = "src/64-64-64";
-    one::az az("", "");
+    one::az az("");
     const auto url = az.url(batch, "0-1-2");
     CHECK(url == expected);
 }
@@ -57,7 +57,7 @@ TEST_CASE(
         "Authorization: SharedKey "
         "acc:ESDuiGR/eRRaEsaWYBREWo2gSfx8iVwQpbgkEuGTznI=";
 
-    one::az az("", "key");
+    one::az az("key");
     one::batch batch;
     batch.root = "acc";
     batch.guid = "guid";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
         "--sink",    "tcp://*:6142",
         "--control", "tcp://0.0.0.0:6141",
         "--fail",    "tcp://0.0.0.0:6140",
-        "--account", "${AZURE_STORAGE_ACCOUNT}",
         "--key",     "${AZURE_STORAGE_ACCESS_KEY}"
     ]
     depends_on:
@@ -27,7 +26,6 @@ services:
         "--sink",    "tcp://api:6144",
         "--control", "tcp://0.0.0.0:6141",
         "--fail",    "tcp://0.0.0.0:6140",
-        "--account", "${AZURE_STORAGE_ACCOUNT}",
         "--key",     "${AZURE_STORAGE_ACCESS_KEY}"
     ]
     depends_on:

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -36,7 +36,6 @@ spec:
         "--sink",    "tcp://*:6142",
         "--control", "tcp://0.0.0.0:6141",
         "--fail",    "tcp://0.0.0.0:6140",
-        "--account", "${AZURE_STORAGE_ACCOUNT}",
         "--key",     "${AZURE_STORAGE_ACCESS_KEY}"
       ]
 
@@ -58,7 +57,6 @@ spec:
         "--sink",    "tcp://api:6144",
         "--control", "tcp://0.0.0.0:6141",
         "--fail",    "tcp://0.0.0.0:6140",
-        "--account", "${AZURE_STORAGE_ACCOUNT}",
         "--key",     "${AZURE_STORAGE_ACCESS_KEY}"
       ]
     - name: api


### PR DESCRIPTION
Storage account is sent from the api and stored as batch.root. The
storage_account az member is not in use and is therefore removed.