### PR TITLE
Turn off flaky integration tests in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,3 @@ jobs:
         run: |
           export VERSION=`git describe --tags`
           docker-compose build
-
-      - name: Run integration tests
-        run: docker-compose -f docker-compose.yml -f docker-compose_tests.yml up --build --exit-code-from test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,4 +26,4 @@ jobs:
       - name: Build docker images
         run: |
           export VERSION=`git describe --tags`
-          docker-compose build
+          docker-compose build --parallel


### PR DESCRIPTION
Reenable when tests are not flaky and are more complete.

Setting AZURE_STORAGE_ACCESS_KEY in manifest and core works from env
but not from docker-compose_test.yml. Depending on timings we
unpredictable results.