### PR TITLE
Partition fetch task

### DIFF
--- a/core/include/oneseismic/tasks.hpp
+++ b/core/include/oneseismic/tasks.hpp
@@ -18,6 +18,9 @@ public:
             zmq::socket_t& fail)
         noexcept (false);
 
+    int  max_task_size() const noexcept (true);
+    void max_task_size(int)    noexcept (false);
+
     manifest_task();
     ~manifest_task();
 

--- a/core/src/manifest.cpp
+++ b/core/src/manifest.cpp
@@ -168,7 +168,7 @@ void fetch_request::basic(const api_request& req) {
     /* set request type-independent parameters */
     /* these really shouldn't fail, and should mean immediate debug */
     this->set_requestid(req.requestid());
-    this->set_storage_endpoint(req.requestid());
+    this->set_storage_endpoint(req.storage_endpoint());
     this->set_root(req.root());
     this->set_guid(req.guid());
     *this->mutable_fragment_shape() = req.shape();

--- a/core/src/manifest.cpp
+++ b/core/src/manifest.cpp
@@ -210,6 +210,7 @@ public:
     std::string pid;
     api_request request;
     fetch_request query;
+    int task_size = 10;
 };
 
 void manifest_task::impl::start_processing(zmq::multipart_t& task) {
@@ -311,7 +312,7 @@ try {
             return;
     }
 
-    const auto chunk_size = ids.size();
+    const auto chunk_size = this->p->task_size;
     const auto chunks = chunk_count(ids.size(), chunk_size);
     auto first = ids.begin();
     auto end = ids.end();
@@ -364,6 +365,18 @@ try {
 } catch (const line_not_found& e) {
     spdlog::info("{} {}", this->p->pid, e.what());
     this->p->failure("line-not-found").send(failure);
+}
+
+int manifest_task::max_task_size() const noexcept (true) {
+    return this->p->task_size;
+}
+
+void manifest_task::max_task_size(int size) noexcept (false) {
+    if (size <= 0) {
+        const auto msg = "expected task size > 0, was {}";
+        throw std::invalid_argument(fmt::format(msg, size));
+    }
+    this->p->task_size = size;
 }
 
 manifest_task::manifest_task() : p(new impl()) {}

--- a/core/src/server-manifest.cpp
+++ b/core/src/server-manifest.cpp
@@ -83,6 +83,7 @@ int main(int argc, char** argv) {
     std::string key;
     bool help = false;
     int ntransfers = 4;
+    int task_size = 10;
 
     auto cli
         = clara::Help(help)
@@ -101,6 +102,9 @@ int main(int argc, char** argv) {
         | clara::Opt(ntransfers, "transfers")
             ["-j"]["--transfers"]
             (fmt::format("Concurrent blob connections, default = {}", ntransfers))
+        | clara::Opt(task_size, "task size")
+            ["-t"]["--task-size"]
+            (fmt::format("Max task size (# of fragments), default = {}", task_size))
         | clara::Opt(key, "key")
             ["-k"]["--key"]
             ("Pre-shared key")
@@ -153,6 +157,12 @@ int main(int argc, char** argv) {
     one::az_manifest az(key);
     one::transfer xfer(ntransfers, az);
     one::manifest_task task;
+    try {
+        task.max_task_size(task_size);
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << "\n";
+        std::exit(EXIT_FAILURE);
+    }
 
     zmq::pollitem_t items[] = {
         { static_cast< void* >(source),  0, ZMQ_POLLIN, 0 },

--- a/core/tests/manifest-task.cpp
+++ b/core/tests/manifest-task.cpp
@@ -55,6 +55,7 @@ std::string make_slice_request() {
     oneseismic::api_request req;
     req.set_root("root");
     req.set_guid("0d235a7138104e00c421e63f5e3261bf2dc3254b");
+    req.set_storage_endpoint("storage");
 
     auto* fragment_shape = req.mutable_shape();
     fragment_shape->set_dim0(2);
@@ -114,6 +115,7 @@ TEST_CASE("Manifest messages are pushed to the right queue") {
         REQUIRE(ok);
 
         CHECK(rep.root() == "root");
+        CHECK(rep.storage_endpoint() == "storage");
         CHECK(rep.fragment_shape().dim0() == 2);
         CHECK(rep.fragment_shape().dim1() == 2);
         CHECK(rep.fragment_shape().dim2() == 2);


### PR DESCRIPTION
Split the set of fragment IDs into multiple separate tasks, to allow
fetch to run in parallel across multiple nodes. The task size is set a
priori, and is not dynamic, as it is not obvious that dynamic task
scalign will even be beneficial, or at least be worth it in terms of
complexity.

The resulting fragments are buffered and put in order at the session/api
node, so clients are unaware of the (possible) parallelism in task
fetch. This means unmodified clients will still work as expected.

Some error and failure signaling is glaringly missing, but as of now
there are no obvious places to signal and fail processes (particularly
in go). This is not made very much worse by parallel fragment tasks, so
it is acceptable for this change.

