### PR TITLE
Add Sessions test for multi-task processes

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -55,6 +55,7 @@ func main() {
 		os.Getenv("AZURE_STORAGE_ACCESS_KEY"),
 		os.Getenv("ZMQ_REQ_ADDR"),
 		os.Getenv("ZMQ_REP_ADDR"),
+		os.Getenv("ZMQ_FAILURE_ADDR"),
 	)
 	if err != nil {
 		golog.Error("creating app: %w", err)

--- a/api/server/multiplexer.go
+++ b/api/server/multiplexer.go
@@ -207,7 +207,7 @@ func (s *sessions) Run(address string, reqNdpt string, repNdpt string) {
 	}
 
 	// TODO: Clean up in case a reply never arrives?
-	processes := make(map[string]procstatus)
+	processes := make(map[string]*procstatus)
 
 	for {
 		select {
@@ -232,7 +232,7 @@ func (s *sessions) Run(address string, reqNdpt string, repNdpt string) {
 				pid: j.pid,
 				request: j.request,
 			}
-			processes[j.pid] = procstatus {
+			processes[j.pid] = &procstatus {
 				out: j.reply,
 				completed: nil,
 			}

--- a/api/server/multiplexer.go
+++ b/api/server/multiplexer.go
@@ -263,7 +263,12 @@ func (s *sessions) Run(reqNdpt string, repNdpt string, failureAddr string) {
 	for {
 		select {
 		case r := <-rep:
-			proc := processes[r.pid]
+			proc, ok := processes[r.pid]
+			if !ok {
+				errmsg := "%s %d/%d dropped; was not in process table"
+				log.Printf(errmsg, r.pid, r.n, r.m)
+				break
+			}
 
 			if proc.completed == nil {
 				proc.completed = make([]bool, r.m)

--- a/api/server/multiplexer_test.go
+++ b/api/server/multiplexer_test.go
@@ -79,8 +79,8 @@ func verifyCorrectReply(t *testing.T, i int, s *sessions, done chan struct{}) {
 func TestMultiplexer(t *testing.T) {
 	s1 := newSessions()
 	s2 := newSessions()
-	go s1.Run("mplx1", "inproc://req1", "inproc://rep1")
-	go s2.Run("mplx2", "inproc://req2", "inproc://rep2")
+	go s1.Run("inproc://req1", "inproc://rep1")
+	go s2.Run("inproc://req2", "inproc://rep2")
 
 	go echoAsWorker(1)
 	go echoAsWorker(2)

--- a/api/server/multiplexer_test.go
+++ b/api/server/multiplexer_test.go
@@ -152,23 +152,24 @@ func TestFailureCancelsProcess(t *testing.T) {
 	}
 
 	for i, proc := range io {
-		select {
-		case m := <-proc.out:
+
+		for m := range proc.out {
 			fmt := "Unexpected message (%s) received - test is likely broken"
 			t.Fatalf(fmt, m)
-
-		case msg := <-proc.err:
-			expected := strconv.Itoa(i) + " manual-failure"
-			if msg != expected {
-				fmt := "Unexpected fail-message = '%s'; want '%s'"
-				t.Errorf(fmt, msg, expected)
-			}
 		}
 
 		_, open := <-proc.out
 		if open {
 			t.Errorf("proc.out (pid = %d) not closed as it should be", i)
 		}
+
+		msg := <-proc.err
+		expected := strconv.Itoa(i) + " manual-failure"
+		if msg != expected {
+			fmt := "Unexpected fail-message = '%s'; want '%s'"
+			t.Errorf(fmt, msg, expected)
+		}
+
 		_, open = <-proc.err
 		if open {
 			t.Errorf("proc.err (pid = %d) not closed as it should be", i)

--- a/api/server/multiplexer_test.go
+++ b/api/server/multiplexer_test.go
@@ -116,8 +116,11 @@ func makeSocket(addr string, socktype zmq.Type) *zmq.Socket {
 }
 
 func TestFailureCancelsProcess(t *testing.T) {
+	reqaddr  := "inproc://req"  + "failure-cancels-process"
+	repaddr  := "inproc://rep"  + "failure-cancels-process"
+	failaddr := "inproc://fail" + "failure-cancels-process"
 	session := newSessions()
-	go session.Run("inproc://req", "inproc://rep", "inproc://fail")
+	go session.Run(reqaddr, repaddr, failaddr)
 
 	/*
 	 * The queue must be connected, otherwise the Schedule() will hang until it
@@ -125,9 +128,9 @@ func TestFailureCancelsProcess(t *testing.T) {
 	 * defer in.Close() shouldn't necessary (will be cleaned up on gc), it is
 	 * to make the variable used somehow
 	 */
-	in := makeSocket("inproc://req", zmq.PULL)
+	in := makeSocket(reqaddr, zmq.PULL)
 	defer in.Close()
-	fail := makeSocket("inproc://fail", zmq.PUSH)
+	fail := makeSocket(failaddr, zmq.PUSH)
 
 	io := make([]procIO, 10)
 	for i := 0; i < 10; i++ {

--- a/api/server/multiplexer_test.go
+++ b/api/server/multiplexer_test.go
@@ -68,9 +68,9 @@ func verifyCorrectReply(t *testing.T, i int, s *sessions, done chan struct{}) {
 	id := strconv.Itoa(i)
 	msg := []byte("message from " + id)
 	job := process{address: "", pid: id, request: msg}
-	res := s.Schedule(&job)
+	io := s.Schedule(&job)
 
-	for result := range res {
+	for result := range io.out {
 		assert.Equal(t, result.payload, msg)
 	}
 	done <- struct{}{}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -17,6 +17,7 @@ func App(
 	accountKey string,
 	zmqReqAddr,
 	zmqRepAddr string,
+	zmqFailureAddr string,
 ) (*iris.Application, error) {
 	app := iris.Default()
 
@@ -30,7 +31,7 @@ func App(
 	}
 
 	sessions := newSessions()
-	go sessions.Run(zmqReqAddr, zmqRepAddr)
+	go sessions.Run(zmqReqAddr, zmqRepAddr, zmqFailureAddr)
 
 	sc := storeController{sURL}
 	app.Get("/", sc.list)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/equinor/oneseismic/api/auth"
-	"github.com/google/uuid"
 	"github.com/kataras/iris/v12"
 )
 
@@ -36,7 +35,7 @@ func App(
 	app.Get("/{guid:string}/slice", sc.dimensions)
 	app.Get("/{guid:string}/slice/{dimension:int32}", sc.lines)
 
-	slicer := createSliceController(zmqReqAddr, zmqRepAddr, storageEndpoint.String(), accountName, uuid.New().String())
+	slicer := createSliceController(zmqReqAddr, zmqRepAddr, storageEndpoint.String(), accountName)
 	app.Get("/{guid:string}/slice/{dim:int32}/{lineno:int32}", slicer.get)
 
 	return app, nil

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -29,14 +29,23 @@ func App(
 		return nil, err
 	}
 
+	sessions := newSessions()
+	go sessions.Run(zmqReqAddr, zmqRepAddr)
+
 	sc := storeController{sURL}
 	app.Get("/", sc.list)
 	app.Get("/{guid:string}", sc.services)
 	app.Get("/{guid:string}/slice", sc.dimensions)
 	app.Get("/{guid:string}/slice/{dimension:int32}", sc.lines)
 
-	slicer := createSliceController(zmqReqAddr, zmqRepAddr, storageEndpoint.String(), accountName)
-	app.Get("/{guid:string}/slice/{dim:int32}/{lineno:int32}", slicer.get)
+	slice := sliceController {
+		slicer: &slicer {
+			root: accountName,
+			endpoint: storageEndpoint.String(),
+			sessions: sessions,
+		},
+	}
+	app.Get("/{guid:string}/slice/{dim:int32}/{lineno:int32}", slice.get)
 
 	return app, nil
 }

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -24,9 +24,10 @@ func TestSlicer(t *testing.T) {
 	accountKey := ""
 	zmqReqAddr := "inproc://" + uuid.New().String()
 	zmqRepAddr := "inproc://" + uuid.New().String()
+	zmqFailureAddr := "inproc://" + uuid.New().String()
 
-	go coreMock(zmqReqAddr, zmqRepAddr)
-	app, err := App(keys, issuer, *storageEndpoint, account, accountKey, zmqReqAddr, zmqRepAddr)
+	go coreMock(zmqReqAddr, zmqRepAddr, zmqFailureAddr)
+	app, err := App(keys, issuer, *storageEndpoint, account, accountKey, zmqReqAddr, zmqRepAddr, zmqFailureAddr)
 	assert.Nil(t, err)
 
 	e := httptest.New(t, app)
@@ -39,7 +40,7 @@ func TestSlicer(t *testing.T) {
 	jsonResponse.Path("$.tiles[0].v").Array().Elements(0.1)
 }
 
-func coreMock(reqNdpt string, repNdpt string) {
+func coreMock(reqNdpt string, repNdpt string, failureAddr string) {
 	in, _ := zmq4.NewSocket(zmq4.PULL)
 	in.Connect(reqNdpt)
 

--- a/api/server/sliceController.go
+++ b/api/server/sliceController.go
@@ -67,10 +67,9 @@ func createSliceController(
 	repNdpt string,
 	storageEndpoint string,
 	root string,
-	mPlexName string,
 ) sliceController {
 	sessions := newSessions()
-	go sessions.Run(mPlexName, reqNdpt, repNdpt)
+	go sessions.Run(reqNdpt, repNdpt)
 	sc := sliceController{slicer: &slicer{mm: &mMultiplexer{storageEndpoint, root}, sessions: sessions}}
 	return sc
 }

--- a/api/server/sliceController.go
+++ b/api/server/sliceController.go
@@ -61,15 +61,3 @@ func (sc *sliceController) get(ctx iris.Context) {
 
 	return
 }
-
-func createSliceController(
-	reqNdpt string,
-	repNdpt string,
-	storageEndpoint string,
-	root string,
-) sliceController {
-	sessions := newSessions()
-	go sessions.Run(reqNdpt, repNdpt)
-	sc := sliceController{slicer: &slicer{mm: &mMultiplexer{storageEndpoint, root}, sessions: sessions}}
-	return sc
-}

--- a/api/server/sliceController.go
+++ b/api/server/sliceController.go
@@ -11,6 +11,7 @@ import (
 
 type sliceModel interface {
 	fetchSlice(
+		auth string,
 		guid string,
 		dim int32,
 		lineno int32,
@@ -38,7 +39,8 @@ func (sc *sliceController) get(ctx iris.Context) {
 		return
 	}
 	requestid := uuid.New().String()
-	slice, err := sc.slicer.fetchSlice(guid, dim, lineno, requestid)
+	auth := ctx.GetHeader("Authorization")
+	slice, err := sc.slicer.fetchSlice(auth, guid, dim, lineno, requestid)
 	if err != nil {
 		ctx.StatusCode(http.StatusNotFound)
 		return

--- a/api/server/sliceController_test.go
+++ b/api/server/sliceController_test.go
@@ -13,7 +13,9 @@ type sliceMock struct {
 	slices map[string]oneseismic.SliceResponse
 }
 
-func (s *sliceMock) fetchSlice(guid string,
+func (s *sliceMock) fetchSlice(
+	auth string,
+	guid string,
 	dim int32,
 	lineno int32,
 	requestid string) (*oneseismic.SliceResponse, error) {

--- a/api/server/sliceModel.go
+++ b/api/server/sliceModel.go
@@ -8,13 +8,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-type messageMultiplexer interface {
-	root() string
-	endpoint() string
-}
-
 type slicer struct {
-	mm messageMultiplexer
+	root string
+	endpoint string
 	sessions *sessions
 }
 
@@ -48,14 +44,6 @@ func makeSliceRequest(
 	return proto.Marshal(&req)
 }
 
-type mMultiplexer struct {
-	storageEndpoint string
-	storageRoot     string
-}
-
-func (m *mMultiplexer) root() string         { return m.storageRoot }
-func (m *mMultiplexer) endpoint() string     { return m.storageEndpoint }
-
 func (s *slicer) fetchSlice(
 	auth string,
 	guid string,
@@ -63,7 +51,7 @@ func (s *slicer) fetchSlice(
 	lineno int32,
 	requestid string) (*oneseismic.SliceResponse, error) {
 
-	req, err := makeSliceRequest(auth, s.mm.endpoint(), s.mm.root(), guid, dim, lineno, requestid)
+	req, err := makeSliceRequest(auth, s.endpoint, s.root, guid, dim, lineno, requestid)
 	if err != nil {
 		return nil, fmt.Errorf("could not make slice request: %w", err)
 	}

--- a/api/server/sliceModel.go
+++ b/api/server/sliceModel.go
@@ -19,6 +19,7 @@ type slicer struct {
 }
 
 func makeSliceRequest(
+	auth string,
 	storageEndpoint string,
 	root string,
 	guid string,
@@ -28,6 +29,7 @@ func makeSliceRequest(
 
 	req := oneseismic.ApiRequest{
 		Requestid:       requestid,
+		Authorization:   auth,
 		Guid:            guid,
 		Root:            root,
 		StorageEndpoint: storageEndpoint,
@@ -55,12 +57,13 @@ func (m *mMultiplexer) root() string         { return m.storageRoot }
 func (m *mMultiplexer) endpoint() string     { return m.storageEndpoint }
 
 func (s *slicer) fetchSlice(
+	auth string,
 	guid string,
 	dim int32,
 	lineno int32,
 	requestid string) (*oneseismic.SliceResponse, error) {
 
-	req, err := makeSliceRequest(s.mm.endpoint(), s.mm.root(), guid, dim, lineno, requestid)
+	req, err := makeSliceRequest(auth, s.mm.endpoint(), s.mm.root(), guid, dim, lineno, requestid)
 	if err != nil {
 		return nil, fmt.Errorf("could not make slice request: %w", err)
 	}

--- a/api/server/sliceModel.go
+++ b/api/server/sliceModel.go
@@ -14,21 +14,19 @@ type slicer struct {
 	sessions *sessions
 }
 
-func makeSliceRequest(
+func (s *slicer) fetchSlice(
 	auth string,
-	storageEndpoint string,
-	root string,
 	guid string,
 	dim int32,
 	lineno int32,
-	requestid string) ([]byte, error) {
+	requestid string) (*oneseismic.SliceResponse, error) {
 
-	req := oneseismic.ApiRequest{
+	msg := oneseismic.ApiRequest {
 		Requestid:       requestid,
 		Authorization:   auth,
 		Guid:            guid,
-		Root:            root,
-		StorageEndpoint: storageEndpoint,
+		Root:            s.root,
+		StorageEndpoint: s.endpoint,
 		Shape: &oneseismic.FragmentShape{
 			Dim0: 64,
 			Dim1: 64,
@@ -41,19 +39,10 @@ func makeSliceRequest(
 			},
 		},
 	}
-	return proto.Marshal(&req)
-}
 
-func (s *slicer) fetchSlice(
-	auth string,
-	guid string,
-	dim int32,
-	lineno int32,
-	requestid string) (*oneseismic.SliceResponse, error) {
-
-	req, err := makeSliceRequest(auth, s.endpoint, s.root, guid, dim, lineno, requestid)
+	req, err := proto.Marshal(&msg)
 	if err != nil {
-		return nil, fmt.Errorf("could not make slice request: %w", err)
+		return nil, fmt.Errorf("Marshalling oneseisimc.ApiRequest: %w", err)
 	}
 
 	proc := process{pid: requestid, request: req}

--- a/api/server/sliceModel.go
+++ b/api/server/sliceModel.go
@@ -48,7 +48,7 @@ func (s *slicer) fetchSlice(
 	proc := process{pid: requestid, request: req}
 	fr := oneseismic.FetchResponse{}
 
-	replyChannel := s.sessions.Schedule(&proc)
+	io := s.sessions.Schedule(&proc)
 
 	/*
 	 * Read and parse messages as they come, and consider the process complete
@@ -65,7 +65,7 @@ func (s *slicer) fetchSlice(
 	 * signal failed processes
 	 */
 	var tiles []*oneseismic.SliceTile
-	for partial := range replyChannel {
+	for partial := range io.out {
 		err = proto.Unmarshal(partial.payload, &fr)
 
 		if err != nil {

--- a/api/server/sliceModel_test.go
+++ b/api/server/sliceModel_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMakeSliceRequest(t *testing.T) {
-	bytes, err := makeSliceRequest("", "", "", 0, 0, "")
+	bytes, err := makeSliceRequest("", "", "", "", 0, 0, "")
 	assert.Nil(t, err)
 	sr := oneseismic.ApiRequest{}
 	err = proto.Unmarshal(bytes, &sr)
@@ -48,7 +48,7 @@ func TestSliceModel(t *testing.T) {
 	}()
 
 	sl := slicer{&mMultiplexer{"", ""}, sessions}
-	slice, err := sl.fetchSlice("guid", 0, 0, "requestid")
+	slice, err := sl.fetchSlice("auth", "guid", 0, 0, "requestid")
 
 	assert.Nil(t, err)
 	assert.NotNil(t, slice)
@@ -74,7 +74,7 @@ func TestModelMissingSlice(t *testing.T) {
 		close(job.reply)
 	}()
 	sl := slicer{&mMultiplexer{"", ""}, sessions}
-	_, err := sl.fetchSlice("guid", 0, 0, "requestid")
+	_, err := sl.fetchSlice("auth", "guid", 0, 0, "requestid")
 
 	assert.NotNil(t, err)
 }

--- a/api/server/sliceModel_test.go
+++ b/api/server/sliceModel_test.go
@@ -9,16 +9,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func TestMakeSliceRequest(t *testing.T) {
-	bytes, err := makeSliceRequest("", "", "", "", 0, 0, "")
-	assert.Nil(t, err)
-	sr := oneseismic.ApiRequest{}
-	err = proto.Unmarshal(bytes, &sr)
-	assert.Nil(t, err)
-	assert.NotNil(t, sr.Shape)
-	assert.NotNil(t, sr.GetSlice())
-}
-
 func TestSliceModel(t *testing.T) {
 	sessions := newSessions()
 

--- a/api/server/sliceModel_test.go
+++ b/api/server/sliceModel_test.go
@@ -33,8 +33,9 @@ func TestSliceModel(t *testing.T) {
 			payload: bytes,
 		}
 
-		job.reply <- pr
-		close(job.reply)
+		job.io.out <- pr
+		close(job.io.out)
+		close(job.io.err)
 	}()
 
 	sl := slicer{
@@ -64,8 +65,9 @@ func TestModelMissingSlice(t *testing.T) {
 			m: 1,
 			payload: bytes,
 		}
-		job.reply <- pr
-		close(job.reply)
+		job.io.out <- pr
+		close(job.io.out)
+		close(job.io.err)
 	}()
 	sl := slicer{
 		root: "",

--- a/api/server/sliceModel_test.go
+++ b/api/server/sliceModel_test.go
@@ -47,7 +47,11 @@ func TestSliceModel(t *testing.T) {
 		close(job.reply)
 	}()
 
-	sl := slicer{&mMultiplexer{"", ""}, sessions}
+	sl := slicer{
+		root: "",
+		endpoint: "",
+		sessions: sessions,
+	}
 	slice, err := sl.fetchSlice("auth", "guid", 0, 0, "requestid")
 
 	assert.Nil(t, err)
@@ -73,7 +77,11 @@ func TestModelMissingSlice(t *testing.T) {
 		job.reply <- pr
 		close(job.reply)
 	}()
-	sl := slicer{&mMultiplexer{"", ""}, sessions}
+	sl := slicer{
+		root: "",
+		endpoint: "",
+		sessions: sessions,
+	}
 	_, err := sl.fetchSlice("auth", "guid", 0, 0, "requestid")
 
 	assert.NotNil(t, err)

--- a/core/include/oneseismic/transfer.hpp
+++ b/core/include/oneseismic/transfer.hpp
@@ -23,6 +23,7 @@ namespace one {
 struct batch {
     std::string root; /* storage-account in azure */
     std::string storage_endpoint; /* url including storage-account */
+    std::string authorization;    /* For azure this is "Bearer $token" */
     std::string guid;
     std::string fragment_shape; /* src/64-64-64 */
 

--- a/core/src/azure.cpp
+++ b/core/src/azure.cpp
@@ -114,13 +114,16 @@ curl_slist* az::http_headers(
         const std::string& job) const {
     const auto date = one::x_ms_date();
     const auto version = one::x_ms_version();
-    const auto auth = this->sign(date, version, batch, job);
 
     // TODO: address leak and flag errors here
     curl_slist* headers = nullptr;
     headers = curl_slist_append(headers, date.c_str());
     headers = curl_slist_append(headers, version);
-    headers = curl_slist_append(headers, auth.c_str());
+    if (not batch.authorization.empty()) {
+        const auto format = "Authorization: {}";
+        const auto auth = fmt::format(format, batch.authorization);
+        headers = curl_slist_append(headers, auth.c_str());
+    }
     return headers;
 }
 

--- a/core/src/manifest.cpp
+++ b/core/src/manifest.cpp
@@ -151,12 +151,14 @@ nlohmann::json get_manifest(
         one::transfer& xfer,
         const std::string& root,
         const std::string& storage_endpoint,
+        const std::string& authorization,
         const std::string& guid)
 noexcept (false) {
 
     one::batch batch;
     batch.root = root;
     batch.storage_endpoint = storage_endpoint;
+    batch.authorization = authorization;
     batch.guid = guid;
     batch.fragment_ids.resize(1);
     manifest_cfg cfg;
@@ -171,6 +173,7 @@ void fetch_request::basic(const api_request& req) {
     this->set_storage_endpoint(req.storage_endpoint());
     this->set_root(req.root());
     this->set_guid(req.guid());
+    this->set_authorization(req.authorization());
     *this->mutable_fragment_shape() = req.shape();
 }
 
@@ -279,6 +282,7 @@ try {
             xfer,
             request.root(),
             request.storage_endpoint(),
+            request.authorization(),
             request.guid()
     );
 

--- a/core/src/server-fragment.cpp
+++ b/core/src/server-fragment.cpp
@@ -15,7 +15,6 @@ int main(int argc, char** argv) {
     std::string sink_address;
     std::string control_address;
     std::string fail_address;
-    std::string key;
     bool help = false;
     int ntransfers = 4;
 
@@ -36,9 +35,6 @@ int main(int argc, char** argv) {
         | clara::Opt(ntransfers, "transfers")
             ["-j"]["--transfers"]
             (fmt::format("Concurrent blob connections, default = {}", ntransfers))
-        | clara::Opt(key, "key")
-            ["-k"]["--key"]
-            ("Pre-shared key")
     ;
 
     auto result = cli.parse(clara::Args(argc, argv));
@@ -51,12 +47,6 @@ int main(int argc, char** argv) {
     if (help) {
         std::cout << cli << "\n";
         std::exit(EXIT_SUCCESS);
-    }
-
-
-    if (key.empty()) {
-        std::cerr << "Need pre-shared key\n" << cli << "\n";
-        std::exit(EXIT_FAILURE);
     }
 
     zmq::context_t ctx;
@@ -80,7 +70,7 @@ int main(int argc, char** argv) {
         std::exit(EXIT_FAILURE);
     }
 
-    one::az az(key);
+    one::az az("");
     one::transfer xfer(ntransfers, az);
     one::fragment_task task;
 

--- a/core/src/server-manifest.cpp
+++ b/core/src/server-manifest.cpp
@@ -80,7 +80,6 @@ int main(int argc, char** argv) {
     std::string sink_address = "tcp://*:68142";
     std::string control_address;
     std::string fail_address;
-    std::string key;
     bool help = false;
     int ntransfers = 4;
     int task_size = 10;
@@ -105,9 +104,6 @@ int main(int argc, char** argv) {
         | clara::Opt(task_size, "task size")
             ["-t"]["--task-size"]
             (fmt::format("Max task size (# of fragments), default = {}", task_size))
-        | clara::Opt(key, "key")
-            ["-k"]["--key"]
-            ("Pre-shared key")
     ;
 
     auto result = cli.parse(clara::Args(argc, argv));
@@ -120,12 +116,6 @@ int main(int argc, char** argv) {
     if (help) {
         std::cout << cli << "\n";
         std::exit(EXIT_SUCCESS);
-    }
-
-
-    if (key.empty()) {
-        std::cerr << "Need pre-shared key\n" << cli << "\n";
-        std::exit(EXIT_FAILURE);
     }
 
     zmq::context_t ctx;
@@ -154,7 +144,7 @@ int main(int argc, char** argv) {
         std::exit(EXIT_FAILURE);
     }
 
-    one::az_manifest az(key);
+    one::az_manifest az("");
     one::transfer xfer(ntransfers, az);
     one::manifest_task task;
     try {

--- a/core/src/worker.cpp
+++ b/core/src/worker.cpp
@@ -165,6 +165,7 @@ one::batch make_batch(const oneseismic::fetch_request& req) noexcept (false) {
     batch.root = req.root();
     batch.guid = req.guid();
     batch.storage_endpoint = req.storage_endpoint();
+    batch.authorization = req.authorization();
     batch.fragment_shape = fmt::format(
         "src/{}-{}-{}",
         req.fragment_shape().dim0(),

--- a/core/tests/azure-transfer-config.cpp
+++ b/core/tests/azure-transfer-config.cpp
@@ -66,3 +66,25 @@ TEST_CASE(
     const auto auth = az.sign("date", "version", batch, "0-1-2");
     CHECK(auth == expected);
 }
+
+std::vector< std::string > to_vector(curl_slist* slist) {
+    auto cur = slist;
+    std::vector< std::string > headers;
+    while (cur) {
+        headers.push_back(cur->data);
+        cur = cur->next;
+    }
+    curl_slist_free_all(slist);
+    return headers;
+}
+
+TEST_CASE(
+        "Bearer authorization is added as a http header",
+        "[azure][az][http]") {
+    one::az az("key");
+    one::batch batch;
+    batch.authorization = "Bearer $token";
+    const auto headers = to_vector(az.http_headers(batch, "pid"));
+    const auto expected = std::string("Authorization: Bearer $token");
+    CHECK_THAT(headers, VectorContains(expected));
+}

--- a/core/tests/testsuite.cpp
+++ b/core/tests/testsuite.cpp
@@ -1,2 +1,17 @@
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
 #include <catch/catch.hpp>
+
+#include <spdlog/spdlog.h>
+
+/*
+ * Use own defined main, because that's catch2's way of allowing custom global
+ * init [1]. spdlog is turned off because otherwise test output gets very
+ * chatty, and not as useful.
+ *
+ * [1] https://github.com/catchorg/Catch2/blob/master/docs/own-main.md
+ */
+int main(int argc, char** argv) {
+    spdlog::set_level(spdlog::level::off);
+    int result = Catch::Session().run( argc, argv );
+    return result;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
         "--sink",    "tcp://*:6142",
         "--control", "tcp://0.0.0.0:6141",
         "--fail",    "tcp://0.0.0.0:6140",
-        "--key",     "${AZURE_STORAGE_ACCESS_KEY}"
     ]
     depends_on:
       - api
@@ -26,7 +25,6 @@ services:
         "--sink",    "tcp://api:6144",
         "--control", "tcp://0.0.0.0:6141",
         "--fail",    "tcp://0.0.0.0:6140",
-        "--key",     "${AZURE_STORAGE_ACCESS_KEY}"
     ]
     depends_on:
       - api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,4 @@ services:
       - LOG_LEVEL
       - ZMQ_REP_ADDR=tcp://*:6144
       - ZMQ_REQ_ADDR=tcp://*:6143
+      - ZMQ_FAILURE_ADDR=tcp://*:6140

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -27,6 +27,7 @@ message api_slice {
 
 message api_request {
     string requestid = 1;
+    string authorization = 7;
     string root = 2;
     string guid = 3;
     string storage_endpoint = 4;
@@ -75,6 +76,7 @@ message fetch_response {
 
 message fetch_request {
     string requestid = 1;
+    string authorization = 9;
     string root = 2;
     string guid = 3;
     string storage_endpoint = 4;


### PR DESCRIPTION
Map lookups in golang returns by value, not by reference, which means
updating the procstatus.completed array was broken. Fix this by storing
a pointer to a procstatus in the map, rather than the object itself.

This was not caught by any tests, since no tests yet used multi-task
processes. Extended the echoAsWorker with a tasks parameter, and
read expected results for the results-channel until it exhausts. This
was manually verified to fail (no-recv on the channel before timeout)
when storing procstatus as objects, not pointer-to-procstatus.