### PR TITLE
Do not upgrade packages when running go generate

### DIFF
--- a/api/generate.go
+++ b/api/generate.go
@@ -1,10 +1,10 @@
 package main
 
 //Swagger doc Generate
-//go:generate go get github.com/swaggo/swag/cmd/swag
+//go:generate go install github.com/swaggo/swag/cmd/swag
 //go:generate swag init
 
 //protobuf generation
 //go:generate mkdir -p oneseismic
-//go:generate go get google.golang.org/protobuf/cmd/protoc-gen-go
+//go:generate go install google.golang.org/protobuf/cmd/protoc-gen-go
 //go:generate protoc -I ../protos ../protos/core.proto --go_out=oneseismic


### PR DESCRIPTION
The swag and protoc-gen-go commands need to be installed during build.
Their versions should respect go.mod and go.sum.

The "go get" command gets the laste version of the package and updates
go.mod and go.sum

The "go install" command seem to behave correctly...