### PR TITLE
Use a logger that does not create race conditions

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -18,13 +18,13 @@ require (
 	github.com/iris-contrib/swagger/v12 v12.0.1
 	github.com/joho/godotenv v1.3.0
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
-	github.com/kataras/golog v0.0.18
 	github.com/kataras/iris/v12 v12.1.8
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/moul/http2curl v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.13.0 // indirect
 	github.com/pebbe/zmq4 v1.2.1
+	github.com/rs/zerolog v1.19.0
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -54,6 +54,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
@@ -170,17 +171,15 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 h1:uC1QfSlInpQF+M0ao65imhwqKnz3Q2z/d8PWZRMQvDM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/kataras/golog v0.0.10 h1:vRDRUmwacco/pmBAm8geLn8rHEdc+9Z4NAr5Sh7TG/4=
 github.com/kataras/golog v0.0.10/go.mod h1:yJ8YKCmyL+nWjERB90Qwn+bdyBZsaQwU3bTVFgkFIp8=
-github.com/kataras/golog v0.0.18 h1:Td7hcKN25yzqB/0SO5iohOsMk5Mq5V9kDtM5apaJLY0=
-github.com/kataras/golog v0.0.18/go.mod h1:jRYl7dFYqP8aQj9VkwdBUXYZSfUktm+YYg1arJILfyw=
 github.com/kataras/iris/v12 v12.1.2/go.mod h1:x8XU9FcsqdBvFyDA9brryw7Px8UZ8lquXwVaYKRzBBc=
 github.com/kataras/iris/v12 v12.1.8 h1:O3gJasjm7ZxpxwTH8tApZsvf274scSGQAUpNe47c37U=
 github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYbq3UhfoFmE=
 github.com/kataras/neffos v0.0.12/go.mod h1:V8lRtjUHJWfwwoJHI0Pv/AYnJa3gvr6TPBTQfGvGEaE=
 github.com/kataras/neffos v0.0.14/go.mod h1:8lqADm8PnbeFfL7CLXh1WHw53dG27MC3pgi2R1rmoTE=
+github.com/kataras/pio v0.0.2 h1:6NAi+uPJ/Zuid6mrAKlgpbI11/zK/lV4B2rxWaJN98Y=
 github.com/kataras/pio v0.0.2/go.mod h1:hAoW0t9UmXi4R5Oyq5Z4irTbaTsOemSrDGUtaTl7Dro=
-github.com/kataras/pio v0.0.8 h1:6pX6nHJk7DAV3x1dEimibQF2CmJLlo0jWVmM9yE9KY8=
-github.com/kataras/pio v0.0.8/go.mod h1:NFfMp2kVP1rmV4N6gH6qgWpuoDKlrOeYi3VrAIWCGsE=
 github.com/kataras/sitemap v0.0.5 h1:4HCONX5RLgVy6G4RkYOV3vKNcma9p236LdGOipJsaFE=
 github.com/kataras/sitemap v0.0.5/go.mod h1:KY2eugMKiPwsJgx7+U103YZehfvNGOXURubcGyk0Bz8=
 github.com/klauspost/compress v1.9.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -250,6 +249,9 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.19.0 h1:hYz4ZVdUgjXTBUmrkrw55j1nHx68LfOKIQk5IYtyScg=
+github.com/rs/zerolog v1.19.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
@@ -401,6 +403,7 @@ golang.org/x/tools v0.0.0-20190606050223-4d9ae51c2468/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190611222205-d73e1c7e250b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59 h1:QjA/9ArTfVTLfEhClDCG7SGrZkZixxWpwNCDiwJfh88=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619210111-0f592d2728bb h1:/7SQoPdMxZ0c/Zu9tBJgMbRE/BmK6i9QXflNJXKAmw0=
 golang.org/x/tools v0.0.0-20200619210111-0f592d2728bb/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/api/server/multiplexer.go
+++ b/api/server/multiplexer.go
@@ -5,7 +5,7 @@ import (
 
 	zmq "github.com/pebbe/zmq4"
 	"github.com/google/uuid"
-	"github.com/kataras/golog"
+	"github.com/rs/zerolog/log"
 )
 
 type job struct {
@@ -176,12 +176,12 @@ func all(a []bool) bool {
 func pipeFailures(addr string, failures chan []string) {
 	r, err := zmq.NewSocket(zmq.PULL)
 	if err != nil {
-		golog.Fatal(err)
+		log.Fatal().Err(err)
 	}
 
 	err = r.Bind(addr)
 	if err != nil {
-		golog.Fatal(err)
+		log.Fatal().Err(err)
 	}
 
 	for {
@@ -193,7 +193,7 @@ func pipeFailures(addr string, failures chan []string) {
 			 * handling can be necessary, but don't deal with it until it
 			 * becomes an issue
 			 */
-			golog.Error(err)
+			log.Fatal().Err(err)
 			continue
 		}
 		failures <- msg
@@ -204,7 +204,7 @@ func (s *sessions) Run(reqNdpt string, repNdpt string, failureAddr string) {
 	req, err := zmq.NewSocket(zmq.PUSH)
 
 	if err != nil {
-		golog.Fatal(err)
+		log.Fatal().Err(err)
 	}
 
 	req.Bind(reqNdpt)
@@ -214,7 +214,7 @@ func (s *sessions) Run(reqNdpt string, repNdpt string, failureAddr string) {
 		r, err := zmq.NewSocket(zmq.DEALER)
 
 		if err != nil {
-			golog.Fatal(err)
+			log.Fatal().Err(err)
 		}
 
 		r.SetIdentity(s.identity)
@@ -225,7 +225,7 @@ func (s *sessions) Run(reqNdpt string, repNdpt string, failureAddr string) {
 			m, err := r.RecvMessageBytes(0)
 
 			if err != nil {
-				golog.Fatal(err)
+				log.Fatal().Err(err)
 			}
 
 			err = partial.loadZMQ(m)
@@ -239,7 +239,7 @@ func (s *sessions) Run(reqNdpt string, repNdpt string, failureAddr string) {
 				 * For now, neither the experience nor infrastructure is in
 				 * place for that, so just log and exit
 				 */
-				golog.Fatalf("Broken partialResult (loadZMQ): %s", err.Error())
+				log.Fatal().Err(err).Msg("Broken partialResult (loadZMQ)")
 			}
 
 			rep <- partial
@@ -266,7 +266,7 @@ func (s *sessions) Run(reqNdpt string, repNdpt string, failureAddr string) {
 			proc, ok := processes[r.pid]
 			if !ok {
 				errmsg := "%s %d/%d dropped; was not in process table"
-				golog.Errorf(errmsg, r.pid, r.n, r.m)
+				log.Error().Msgf(errmsg, r.pid, r.n, r.m)
 				break
 			}
 
@@ -294,10 +294,10 @@ func (s *sessions) Run(reqNdpt string, repNdpt string, failureAddr string) {
 			 */
 			if !ok {
 				errmsg := "%s failed (%s); was not in process table"
-				golog.Errorf(errmsg, pid, msg)
+				log.Error().Msgf(errmsg, pid, msg)
 			} else {
 				errmsg := "%s failed (%s); removing from process table"
-				golog.Errorf(errmsg, pid, msg)
+				log.Error().Msgf(errmsg, pid, msg)
 				/*
 				 * The order of statements creates an interesting race
 				 * condition:

--- a/api/server/sliceController.go
+++ b/api/server/sliceController.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/equinor/oneseismic/api/oneseismic"
 	"github.com/google/uuid"
-	"github.com/kataras/golog"
+	"github.com/rs/zerolog/log"
 	"github.com/kataras/iris/v12"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -45,7 +45,7 @@ func (f *failure) status() int {
 		return http.StatusUnauthorized
 
 	default:
-		golog.Errorf("unknown failure; key = %s", f.key)
+		log.Error().Msgf("unknown failure; key = %s", f.key)
 		return http.StatusInternalServerError
 	}
 }
@@ -102,7 +102,7 @@ func (sc *sliceController) get(ctx iris.Context) {
 			ctx.StatusCode(e.status())
 
 		default:
-			golog.Error(e)
+			log.Error().Err(e)
 			ctx.StatusCode(http.StatusInternalServerError)
 		}
 		return

--- a/api/server/sliceModel.go
+++ b/api/server/sliceModel.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/equinor/oneseismic/api/oneseismic"
-	"github.com/kataras/golog"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -77,7 +77,7 @@ func (s *slicer) fetchSlice(
 			switch x := fr.Function.(type) {
 			default:
 				msg := "%s Expected FetchResponse.Function = %T; was %T"
-				golog.Errorf(msg, requestid, slice, x)
+				log.Error().Msgf(msg, requestid, slice, x)
 				return nil, fmt.Errorf("internal error")
 			}
 		}


### PR DESCRIPTION
When running "go test -race ./..." the golog package cannot be used
inside goroutines. Uncertain if golog introduces race conditions during
runtime.

TODO: Consider aligning logging from iris if we continue to use iris.