### PR TITLE
Use XDG_CACHE_HOME for storing token

### DIFF
--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -90,9 +90,10 @@ class cube:
 
 
 class azure_auth:
-    def __init__(self):
+    def __init__(self, cache_dir=None):
         self.app = None
         self.scopes = None
+        self.cache_dir = cache_dir
 
     def token(self):
         """ Loads a token from cache
@@ -106,7 +107,7 @@ class azure_auth:
         """
         if not self.app:
             config_path = os.path.join(
-                XDG_CACHE_HOME,
+                self.cache_dir or XDG_CACHE_HOME,
                 "oneseismic",
                 "config.json"
             )
@@ -119,7 +120,7 @@ class azure_auth:
                 )
 
             cache_file = os.path.join(
-                XDG_CACHE_HOME,
+                self.cache_dir or XDG_CACHE_HOME,
                 "oneseismic",
                 "accessToken.json"
             )
@@ -155,9 +156,9 @@ class azure_auth:
 
 
 class client:
-    def __init__(self, endpoint, auth=azure_auth()):
+    def __init__(self, endpoint, auth=None, cache_dir=None):
         self.endpoint = endpoint
-        self.auth = auth
+        self.auth = auth or azure_auth(cache_dir)
 
     def token(self):
         return self.auth.token()

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -4,8 +4,8 @@ import logging
 import msal
 import numpy as np
 import os
-from pathlib import Path
 import requests
+from xdg import XDG_CACHE_HOME
 
 
 def assemble_slice(parts):
@@ -72,7 +72,7 @@ class cube:
         ----------
 
         dim : int
-            The dimension allong which to slice
+            The dimension along which to slice
         lineno : int
             The line number we would like to fetch. This corresponds to the
             axis labels given in the dim<n> members. In order to fetch the nth
@@ -106,8 +106,8 @@ class azure_auth:
         """
         if not self.app:
             config_path = os.path.join(
-                Path.home(),
-                ".oneseismic",
+                XDG_CACHE_HOME,
+                "oneseismic",
                 "config.json"
             )
             try:
@@ -119,8 +119,8 @@ class azure_auth:
                 )
 
             cache_file = os.path.join(
-                Path.home(),
-                ".oneseismic",
+                XDG_CACHE_HOME,
+                "oneseismic",
                 "accessToken.json"
             )
             cache = msal.SerializableTokenCache()

--- a/python/oneseismic/login/__main__.py
+++ b/python/oneseismic/login/__main__.py
@@ -11,9 +11,10 @@ def main(argv):
     parser.add_argument('--client-id', type=str, required=True)
     parser.add_argument('--auth-server', type=str, required=True)
     parser.add_argument('--scopes', type=str, nargs='+', required=True)
+    parser.add_argument('--cache-dir', type=str, required=False)
 
     args = parser.parse_args(argv)
-    login(args.client_id, args.auth_server, args.scopes)
+    login(args.client_id, args.auth_server, args.scopes, args.cache_dir)
 
 if __name__ == '__main__':
     main((sys.argv[1:]))

--- a/python/oneseismic/login/login.py
+++ b/python/oneseismic/login/login.py
@@ -4,6 +4,7 @@ import msal
 import os
 from pathlib import Path
 import sys
+from xdg import XDG_CACHE_HOME
 
 def store_config(client_id, auth_server, scopes, cache_dir):
     config_file = os.path.join(
@@ -52,7 +53,7 @@ def login(client_id, auth_server, scopes):
     url to provide credentials. Once this is done, the token can be loaded from
     the cache and refreshed non-interactively.
 
-    For non-interactive workflows run the oneseismic-login exectutale before
+    For non-interactive workflows run the oneseismic-login executable before
     running your script.
 
     Parameters
@@ -68,7 +69,7 @@ def login(client_id, auth_server, scopes):
         <tenant-id> with the Directory (tenant) ID in which the app registration
         was created.
     """
-    cache_dir = os.path.join(Path.home(), ".oneseismic")
+    cache_dir = os.path.join(XDG_CACHE_HOME, "oneseismic")
     Path(cache_dir).mkdir(exist_ok=True)
 
     store_config(client_id, auth_server, scopes, cache_dir)

--- a/python/oneseismic/login/login.py
+++ b/python/oneseismic/login/login.py
@@ -46,7 +46,7 @@ def fetch_token(client_id, auth_server, scopes, cache_dir):
     open(cache_file, "w").write(cache.serialize())
 
 
-def login(client_id, auth_server, scopes):
+def login(client_id, auth_server, scopes, cache_dir=None):
     """ Log in to one seismic
 
     Fetches token and caches it on disk. This function will prompt user to open
@@ -69,7 +69,7 @@ def login(client_id, auth_server, scopes):
         <tenant-id> with the Directory (tenant) ID in which the app registration
         was created.
     """
-    cache_dir = os.path.join(XDG_CACHE_HOME, "oneseismic")
+    cache_dir = cache_dir or os.path.join(XDG_CACHE_HOME, "oneseismic")
     Path(cache_dir).mkdir(exist_ok=True)
 
     store_config(client_id, auth_server, scopes, cache_dir)

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -9,3 +9,4 @@ requests_mock
 segyio
 tqdm
 ujson
+xdg

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     segyio
     tqdm
     ujson
+    xdg
 
 setup_requires =
     pytest-runner


### PR DESCRIPTION
Avoid polluting home directory by adhering to the xdg specification [1].

[1] https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html