### PR TITLE
Use pip to install oneseismic in tests

### DIFF
--- a/docker-compose_tests.yml
+++ b/docker-compose_tests.yml
@@ -14,7 +14,7 @@ services:
       - TOKEN_ENDPOINT_SUBJECT=https://storage.azure.com
 
   az:
-    image: mcr.microsoft.com/azure-storage/azurite:3.8.0
+    image: mcr.microsoft.com/azure-storage/azurite:latest
     command: azurite-blob --blobHost 0.0.0.0 --oauth basic --loose --cert /tests/ssl/az.pem --key /tests/ssl/key.pem
     volumes:
       - ./tests/ssl:/tests/ssl

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:buster
+FROM python:3.8-buster
 
 WORKDIR /python
 COPY /python .

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,6 +2,12 @@ FROM python:buster
 
 WORKDIR /python
 COPY /python .
+# Prerelease versions of azure-storage-blob might use versions of x-ms-version
+# that Azurite do not support yet.
+# For now, just trust ms to not release azure-storage-blob versions until Azurite
+# supports the same x-ms-version value.
+# By using pip to install packages, prerelease versions will not be installed.
+RUN pip install -r requirements-dev.txt
 RUN python3 setup.py install
 RUN python3 setup.py test
 


### PR DESCRIPTION
Use pip to install packages in test

Require python 3.8 image for tests