### PR TITLE
Trim fat from core/ docker image

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -10,16 +10,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     pkg-config \
     wget \
     unzip \
-    libzmq3-dev \
+    libzmq5-dev \
     libspdlog-dev \
     libhiredis-dev \
     libmsgpack-dev \
     ca-certificates
-RUN apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists
 
-FROM baseimg AS dependencies
 WORKDIR /src
 RUN wget -q https://github.com/fmtlib/fmt/releases/download/${FMT_VERSION}/fmt-${FMT_VERSION}.zip
 RUN wget -q https://github.com/zeromq/cppzmq/archive/v${ZMQ_VERSION}.zip
@@ -28,7 +24,7 @@ RUN unzip fmt-${FMT_VERSION}.zip && unzip v${ZMQ_VERSION}.zip
 WORKDIR /src/fmt-${FMT_VERSION}/build
 RUN cmake \
     -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_SHARED_LIBS=OFF \
     -DFMT_TEST=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr \
     /src/fmt-${FMT_VERSION}
@@ -38,24 +34,36 @@ WORKDIR /src/cppzmq-${ZMQ_VERSION}/build
 RUN cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCPPZMQ_BUILD_TESTS=OFF \
-    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr \
     /src/cppzmq-${ZMQ_VERSION}
 RUN make install -j2
 RUN rm -rf /src
 
-FROM dependencies AS source
+FROM baseimg AS builder
 WORKDIR /src
 COPY core/ core
 
-FROM source AS build
 WORKDIR /src/build
 RUN cmake \
     -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_SHARED_LIBS=OFF \
     -DBUILD_TESTING=OFF \
     -DBUILD_PYTHON=OFF \
     -DCMAKE_INSTALL_PREFIX=/usr \
     /src/core
 RUN make -j4 install
-RUN rm -rf /src
+
+FROM debian:buster-slim as deployer
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libzmq5 \
+    libcurl4 \
+    libcurl4-gnutls-dev \
+    libhiredis0.14 \
+    ca-certificates
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists
+COPY --from=builder /usr/bin/oneseismic-manifest /bin/oneseismic-manifest
+COPY --from=builder /usr/bin/oneseismic-fragment /bin/oneseismic-fragment


### PR DESCRIPTION
The core/ docker image was obnoxiously large, upwards of 1.3G. This is
largely because the build image itself was a part of the final, which
includes development packages. Some fairly small changes pushes the size
down to approx 100M [1].

Two main changes push down the size:
  1. Build artifacts are copied into a clean base image with only
     runtime dependencies installed. This is the big driver.
  2. What's build from source is statically linked.

[1] which is still massive, approx. the size of the api/ image, which is
    what you would expect