### PR TITLE
Add entry endpoint /query/:guid and cube.shape

### DIFF
--- a/api/cmd/query/main.go
+++ b/api/cmd/query/main.go
@@ -201,6 +201,12 @@ func main() {
 	onbehalf := auth.OnBehalfOf(openidcfg.TokenEndpoint, opts.clientID, opts.clientSecret)
 	app := gin.Default()
 	app.GET(
+		"/query/:guid",
+		validate,
+		onbehalf,
+		slice.Entry,
+	)
+	app.GET(
 		"/query/:guid/slice/:dimension/:lineno",
 		validate,
 		onbehalf,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     ]
     depends_on:
       - api
+      - storage
   fragment:
     image: oneseismic.azurecr.io/base:${VERSION:-latest}
     build:
@@ -43,6 +44,8 @@ services:
     command: [
         "oneseismic-query",
     ]
+    depends_on:
+      - storage
     environment:
       - HOST_ADDR=0.0.0.0:8080
       - AUTHSERVER

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -42,9 +42,26 @@ class cube:
     def __init__(self, id, client):
         self.client = client
         self.id = id
-        self._dim0 = None
-        self._dim1 = None
-        self._dim2 = None
+        self._shape = None
+
+    @property
+    def shape(self):
+        """ Shape of the cube
+
+        N-element int-tuple.
+
+        Notes
+        -----
+        The shape is immutable and the result may be cached.
+        """
+        if self._shape is not None:
+            return self._shape
+
+        resource = f"query/{self.id}"
+        r = self.client.get(resource)
+        r.raise_for_status()
+        self._shape = tuple(int(dim['size']) for dim in r.json()['dimensions'])
+        return self._shape
 
     def slice(self, dim, lineno):
         """ Fetch a slice

--- a/python/oneseismic/client/tests/client_test.py
+++ b/python/oneseismic/client/tests/client_test.py
@@ -87,6 +87,20 @@ client = client('http://api', auth=no_auth())
 cube = client.cube('test_id')
 
 @requests_mock.Mocker(kw='m')
+def test_shape(**kwargs):
+    response = '''{
+        "dimensions":[
+            {"dimension":0,"location":"query/test_id/slice/0","size":4},
+            {"dimension":1,"location":"query/test_id/slice/1","size":3},
+            {"dimension":2,"location":"query/test_id/slice/2","size":2}
+        ],
+        "pid":"pid-test-shape"
+    }'''
+
+    kwargs['m'].get('http://api/query/test_id', text = response)
+    assert cube.shape == (4, 3, 2)
+
+@requests_mock.Mocker(kw='m')
 def test_slice(**kwargs):
     pid_0_12 = '{ "result": "result/pid-0-12", "authorization": "" }'
     pid_1_22 = '{ "result": "result/pid-1-22", "authorization": "" }'


### PR DESCRIPTION
Add a cube entry point that describes the available features for a cube,
and provide some basic metadata (for now, just the dimensions). The
dimension is re-introduced in Python through the more general cube.shape
attribute.

The implementation of slice.Entry is pretty rough - it does not really
belong on the Slice struct and is mostly copy-paste of the
fetch-and-parse logic from Slice.Get. It will certainly be refactored
quite soon, but is written as-is to highlight what exactly is (typical)
common code. Please note the absence of tests is with this in mind -
tests should be introduced with said refactoring.