### PR TITLE
Add load balancing message broker

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(oneseismic
     src/worker.cpp
     src/manifest.cpp
     src/messages.cpp
+    src/load_balancer.cpp
 )
 add_library(oneseismic::oneseismic ALIAS oneseismic)
 target_include_directories(oneseismic
@@ -163,6 +164,7 @@ add_executable(tests
     tests/geometry.cpp
     tests/azure-transfer-config.cpp
     tests/messages.cpp
+    tests/load_balancer.cpp
 )
 target_link_libraries(tests
     PRIVATE

--- a/core/include/oneseismic/load_balancer.hpp
+++ b/core/include/oneseismic/load_balancer.hpp
@@ -1,0 +1,36 @@
+#include <vector>
+
+#ifndef ONESEISMIC_LOAD_BALANCER_HPP
+#define ONESEISMIC_LOAD_BALANCER_HPP
+
+namespace one {
+
+[[noreturn]] void load_balancer(
+    const std::string& frontend,
+    const std::string& backend,
+    int heartbeat_interval = 1000,
+    int heartbeat_liveness = 3);
+
+namespace detail { namespace load_balancer {
+
+struct worker {
+    std::string identity;
+    std::time_t expiry;
+};
+
+void run(
+    zmq::socket_t& frontend,
+    zmq::socket_t& backend,
+    zmq::multipart_t& task,
+    std::vector< worker >& available_workers,
+    int heartbeat_interval,
+    int heartbeat_liveness,
+    std::time_t current_time);
+
+void configure_sockets(zmq::socket_t&, zmq::socket_t&);
+
+}}
+
+}
+
+#endif //ONESEISMIC_LOAD_BALANCER_HPP

--- a/core/src/load_balancer.cpp
+++ b/core/src/load_balancer.cpp
@@ -1,0 +1,209 @@
+#include <algorithm>
+#include <ctime>
+#include <vector>
+#include <spdlog/spdlog.h>
+#include <zmq.hpp>
+#include <zmq_addon.hpp>
+
+#include <oneseismic/load_balancer.hpp>
+
+namespace {
+
+using worker = one::detail::load_balancer::worker;
+
+void update_worker(
+    std::vector< worker >& workers,
+    const std::string& identity,
+    const std::time_t expiry
+) noexcept (false) {
+    auto w = std::find_if(
+        std::begin(workers),
+        std::end(workers),
+        [&identity] (auto item) { return item.identity == identity; }
+    );
+
+    /*
+     * A HEARTBEAT from a worker not in the pool is clearly a sign that
+     * something is wrong. This could be due to dropped READY message, network
+     * instabilities or the queue being restarted. However, adding the worker to
+     * the pool is probably the best we can do under the circumstances.
+     */
+    if (w == workers.end()) {
+        spdlog::error(
+            "Unexpected HEARTBEAT received from worker not in pool. This could "
+            "be due to a dropped READY message, a network issue or the queue "
+            "being restarted. The worker has been added back to the pool."
+        );
+        workers.push_back(worker{identity, expiry});
+    }
+
+    w->expiry = expiry;
+}
+
+void purge_workers(
+    std::vector< worker >& workers,
+    std::time_t current_time
+) noexcept (false) {
+    for (auto worker = workers.begin(); worker < workers.end(); ++worker) {
+        if (worker->expiry < current_time)
+            workers.erase(worker);
+    }
+}
+
+bool send_to_worker(
+    std::vector< worker >& workers,
+    zmq::multipart_t task,
+    zmq::socket_t& backend
+) noexcept (false) {
+    /*
+     * Send task to a worker and remove worker from pool. Return false if send
+     * fails with EAGAIN or EHOSTUNREACH, true if send is successful.
+     *
+     */
+    auto identity = workers[0].identity;
+    workers.erase(workers.begin());
+    task.pushstr(identity);
+    try {
+        return task.send(backend);
+    } catch (zmq::error_t& e) {
+        if (e.num() == EHOSTUNREACH)
+            return false;
+        throw e;
+    }
+}
+
+}
+
+namespace one {
+
+namespace detail { namespace load_balancer {
+
+void run(
+    zmq::socket_t& frontend,
+    zmq::socket_t& backend,
+    zmq::multipart_t& task,
+    std::vector< worker >& available_workers,
+    int heartbeat_interval,
+    int heartbeat_liveness,
+    std::time_t current_time
+) noexcept (false) {
+
+    zmq::pollitem_t items[] = {
+            {static_cast< void* >(backend),  0, ZMQ_POLLIN, 0},
+            {static_cast< void* >(frontend), 0, ZMQ_POLLIN, 0}
+    };
+
+    /*
+     * Poll frontend only if there are available workers and the previous task
+     * was successfully sent to a worker.
+     */
+    if (!available_workers.empty() and task.empty())
+        zmq::poll(items, 2, heartbeat_interval);
+    else
+        zmq::poll(items, 1, heartbeat_interval);
+
+    // Handle worker control messages from backend
+    if (items[0].revents & ZMQ_POLLIN) {
+        auto msg = zmq::multipart_t(backend);
+        auto expiry = current_time + heartbeat_interval * heartbeat_liveness;
+
+        auto identity = msg[0].to_string();
+        auto message  = msg[1].to_string();
+
+        if (std::strcmp(message.c_str(), "READY") == 0)
+            available_workers.push_back(worker{identity, expiry});
+        else if (std::strcmp(message.c_str(), "HEARTBEAT") == 0)
+            update_worker(available_workers, identity, expiry);
+        else
+            spdlog::error("Invalid message from worker: {}", message);
+    }
+
+    /*
+     * Push message from frontend to available worker. A copy of the message
+     * is kept around in case the send fails.
+     */
+    if (items[1].revents & ZMQ_POLLIN) {
+        task = zmq::multipart_t(frontend);
+        if (send_to_worker(available_workers, task.clone(), backend))
+            task.clear();
+    }
+
+    /*
+     * If the message fails to send we try to send it to other workers in
+     * the pool until the pool is exhausted, in which case the message is
+     * kept around so we can try again when more workers are added to the
+     * the pool.
+     */
+    while (!task.empty() and !available_workers.empty()) {
+        if (send_to_worker(available_workers, task.clone(), backend))
+            task.clear();
+    }
+
+    purge_workers(available_workers, current_time);
+}
+
+void configure_sockets(zmq::socket_t& frontend, zmq::socket_t& backend) {
+    backend.setsockopt(ZMQ_ROUTER_MANDATORY, 1);
+}
+
+}}
+
+[[noreturn]] void load_balancer(
+    const std::string& front,
+    const std::string& back,
+    int heartbeat_interval,
+    int heartbeat_liveness
+) {
+    /*
+     * Message broker that will distribute tasks to workers as they become
+     * available.
+     *
+     * This solution is based on the Robust Reliable Queuing (Paranoid Pirate
+     * Pattern) [1], with some key differences:
+     *
+     *     1. Replies from workers are not routed back to the client. Since the
+     *        workers don't send a reply when the job is done, a READY message
+     *        is sent instead, indicating that the worker is available to
+     *        receive new tasks.
+     *     2. Tasks arrive on a PULL socket.
+     *     3. Messages will not be dropped if they fail to be sent to a worker.
+     *        This has the cost of making a copy of each incoming message and
+     *        slightly more convoluted control flow, but should be worth it due
+     *        to the high cost of dropped messages (entire job must be
+     *        rescheduled).
+     *
+     * TODO: If resilience in the form of failed jobs being rescheduled or
+     *       similar, the need for the retry mechanism should be reevaluated.
+     *
+     * The advantage of this approach over PUSH-PULL is that jobs are sent to
+     * idle workers, whereas PUSH-PULL distributes round robin. A disadvantage
+     * is that the queue becomes a single point of failure, and a single point
+     * for all messages to pass through, while PUSH-PULL is N-to-N.
+     *
+     * [1] https://zguide.zeromq.org/docs/chapter4/
+     */
+    zmq::context_t ctx;
+    zmq::socket_t frontend(ctx, ZMQ_PULL);
+    zmq::socket_t backend(ctx, ZMQ_ROUTER);
+    detail::load_balancer::configure_sockets(frontend, backend);
+
+    frontend.bind(front);
+    backend.bind(back);
+
+    zmq::multipart_t task;
+    std::vector< worker > available_workers;
+
+    while (true) {
+        detail::load_balancer::run(
+            frontend,
+            backend,
+            task,
+            available_workers,
+            heartbeat_liveness,
+            heartbeat_interval,
+            std::time(nullptr)
+        );
+    }
+}
+
+}

--- a/core/tests/load_balancer.cpp
+++ b/core/tests/load_balancer.cpp
@@ -1,0 +1,132 @@
+#include <catch/catch.hpp>
+#include <ctime>
+#include <zmq.hpp>
+#include <zmq_addon.hpp>
+
+#include <oneseismic/load_balancer.hpp>
+
+static constexpr int HEARTBEAT_INTERVAL = 10;
+
+namespace {
+
+using worker = one::detail::load_balancer::worker;
+
+zmq::multipart_t task() {
+    zmq::multipart_t task;
+    task.addstr("part1");
+    task.addstr("part2");
+    return task;
+}
+
+}
+
+TEST_CASE("Messages are pushed through to available workers") {
+    zmq::context_t ctx;
+    zmq::socket_t client(ctx, ZMQ_PUSH);
+    zmq::socket_t worker1(ctx, ZMQ_DEALER);
+    zmq::socket_t worker2(ctx, ZMQ_DEALER);
+    zmq::socket_t queue_frontend(ctx, ZMQ_PULL);
+    zmq::socket_t queue_backend(ctx, ZMQ_ROUTER);
+
+    one::detail::load_balancer::configure_sockets(queue_backend, queue_backend);
+    queue_frontend.bind("inproc://queue_frontend");
+    queue_backend.bind("inproc://queue_backend");
+    worker1.connect("inproc://queue_backend");
+    worker2.connect("inproc://queue_backend");
+    client.connect("inproc://queue_frontend");
+
+    std::vector< worker > available_workers;
+    zmq::multipart_t t;
+
+    auto load_balancer_run = [&] (
+            int hearthbeat_interval,
+            int heartbeat_liveness,
+            std::time_t time
+    ) {
+        one::detail::load_balancer::run(
+                queue_frontend,
+                queue_backend,
+                t,
+                available_workers,
+                hearthbeat_interval,
+                heartbeat_liveness,
+                time
+        );
+    };
+
+    SECTION("Job is passed to available worker") {
+        int heartbeat_interval = 1000;
+        int heartbeat_liveness = 3;
+        std::time_t time = 1000;
+
+        worker1.send(zmq::message_t("READY"), zmq::send_flags::none);
+        load_balancer_run(heartbeat_interval, heartbeat_liveness, time);
+        task().send(client);
+        load_balancer_run(heartbeat_interval, heartbeat_liveness, time);
+
+        auto result = zmq::multipart_t(worker1);
+        CHECK(result[0].to_string() == "part1");
+        CHECK(result[1].to_string() == "part2");
+    }
+
+    SECTION("Job is resent to another worker if it fails to send") {
+        int heartbeat_interval = 1000;
+        int heartbeat_liveness = 3;
+        std::time_t time = 1000;
+
+        worker1.send(zmq::message_t("READY"), zmq::send_flags::none);
+        load_balancer_run(heartbeat_interval, heartbeat_liveness, time);
+        worker1.disconnect("inproc://queue_backend");
+        task().send(client);
+        load_balancer_run(heartbeat_interval, heartbeat_liveness, time);
+        worker2.send(zmq::message_t("READY"), zmq::send_flags::none);
+        load_balancer_run(heartbeat_interval, heartbeat_liveness, time);
+        load_balancer_run(heartbeat_interval, heartbeat_liveness, time);
+
+        auto result = zmq::multipart_t(worker2);
+        CHECK(result[0].to_string() == "part1");
+        CHECK(result[1].to_string() == "part2");
+    }
+
+    SECTION("Worker is removed from pool on HEARTBEAT timeout") {
+        int heartbeat_interval = 1000;
+        int heartbeat_liveness = 3;
+        std::time_t time = 1000;
+
+        worker1.send(zmq::message_t("READY"), zmq::send_flags::none);
+        load_balancer_run(heartbeat_interval, heartbeat_liveness, time);
+        load_balancer_run(
+            heartbeat_interval,
+            heartbeat_liveness,
+            time + heartbeat_liveness * heartbeat_interval + 1
+        );
+
+        CHECK(available_workers.empty());
+    }
+
+    SECTION("Worker is *not* removed from pool when HEARTBEAT is received "
+            "within timeout interval") {
+        int heartbeat_interval = 1000;
+        int heartbeat_liveness = 3;
+        std::time_t time = 1000;
+
+        worker1.send(zmq::message_t("READY"), zmq::send_flags::none);
+        worker2.send(zmq::message_t("READY"), zmq::send_flags::none);
+        load_balancer_run(heartbeat_interval, heartbeat_liveness, time);
+        load_balancer_run(heartbeat_interval, heartbeat_liveness, time);
+        worker1.send(zmq::message_t("HEARTBEAT"), zmq::send_flags::none);
+        load_balancer_run(
+            heartbeat_interval,
+            heartbeat_liveness,
+            time + heartbeat_interval
+        );
+        load_balancer_run(
+            heartbeat_interval,
+            heartbeat_liveness,
+            time + heartbeat_liveness * heartbeat_interval + 1
+        );
+
+        CHECK(available_workers.size() == 1);
+    }
+
+}


### PR DESCRIPTION
Message broker that will distribute tasks to workers as they become
available.

The advantage of this approach over PUSH-PULL is that jobs are sent to
idle workers, whereas PUSH-PULL distributes round robin. A disadvantage
is that the queue becomes a single point of failure, and a single point
for all messages to pass through, while PUSH-PULL is N-to-N.