### PR TITLE
Add load balancing message broker

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(oneseismic
     src/worker.cpp
     src/manifest.cpp
     src/messages.cpp
+    src/load_balancer.cpp
 )
 add_library(oneseismic::oneseismic ALIAS oneseismic)
 target_include_directories(oneseismic
@@ -163,6 +164,7 @@ add_executable(tests
     tests/geometry.cpp
     tests/azure-transfer-config.cpp
     tests/messages.cpp
+    tests/load_balancer.cpp
 )
 target_link_libraries(tests
     PRIVATE

--- a/core/include/oneseismic/load_balancer.hpp
+++ b/core/include/oneseismic/load_balancer.hpp
@@ -1,0 +1,18 @@
+#include <vector>
+#include <zmq.hpp>
+
+#ifndef ONESEISMIC_LOAD_BALANCER_HPP
+#define ONESEISMIC_LOAD_BALANCER_HPP
+
+namespace one {
+
+void load_balancer(
+    zmq::socket_t& frontend,
+    zmq::socket_t& backend,
+    zmq::socket_t& control,
+    std::time_t request_timeout
+);
+
+}
+
+#endif //ONESEISMIC_LOAD_BALANCER_HPP

--- a/core/src/load_balancer.cpp
+++ b/core/src/load_balancer.cpp
@@ -1,0 +1,60 @@
+#include <spdlog/spdlog.h>
+#include <zmq.hpp>
+#include <zmq_addon.hpp>
+
+#include <oneseismic/load_balancer.hpp>
+
+namespace one {
+
+void load_balancer(
+        zmq::socket_t& frontend,
+        zmq::socket_t& backend,
+        zmq::socket_t& control,
+        std::time_t request_timeout
+) {
+    /*
+     * Message broker that will distribute tasks to workers as they become
+     * available.
+     *
+     * The advantage of this approach over PUSH-PULL is that jobs are sent to
+     * idle workers, whereas PUSH-PULL distributes round robin. A disadvantage
+     * is that the queue becomes a single point of failure, and a single point
+     * for all messages to pass through, while PUSH-PULL is N-to-N.
+     */
+
+    while (true) {
+        zmq::pollitem_t items[] = {
+            { static_cast< void* >(frontend),  0, ZMQ_POLLIN, 0 },
+            { static_cast< void* >(control), 0, ZMQ_POLLIN, 0 },
+        };
+
+        int poll = zmq::poll(items, 2, request_timeout);
+
+        /*
+         * Send an empty message to workers on timeout event. This will trigger
+         * a new request from the workers.
+         */
+        if (poll == 0) {
+            zmq::message_t msg;
+            while (backend.recv(msg, zmq::recv_flags::dontwait)) {
+                backend.send(zmq::message_t(), zmq::send_flags::none);
+            }
+        }
+
+        /*
+         *
+         */
+        if (items[0].revents & ZMQ_POLLIN) {
+            auto task = zmq::multipart_t(frontend);
+            zmq::message_t msg;
+            backend.recv(msg, zmq::recv_flags::none);
+            task.send(backend);
+        }
+
+        if (items[1].revents & ZMQ_POLLIN) {
+            break;
+        }
+    }
+}
+
+}

--- a/core/tests/load_balancer.cpp
+++ b/core/tests/load_balancer.cpp
@@ -1,0 +1,78 @@
+#include <catch/catch.hpp>
+#include <thread>
+#include <zmq.hpp>
+#include <zmq_addon.hpp>
+
+#include <oneseismic/load_balancer.hpp>
+
+namespace {
+
+zmq::multipart_t task() {
+    zmq::multipart_t task;
+    task.addstr("part1");
+    task.addstr("part2");
+    return task;
+}
+
+}
+
+TEST_CASE("Messages are pushed through to available workers") {
+    zmq::context_t ctx;
+    zmq::socket_t client(ctx, ZMQ_PUSH);
+    zmq::socket_t worker1(ctx, ZMQ_REQ);
+    zmq::socket_t worker2(ctx, ZMQ_REQ);
+    zmq::socket_t controller(ctx, ZMQ_PUSH);
+
+    zmq::socket_t frontend(ctx, ZMQ_PULL);
+    zmq::socket_t backend(ctx, ZMQ_REP);
+    zmq::socket_t control(ctx, ZMQ_PULL);
+
+    frontend.bind("inproc://frontend");
+    backend.bind("inproc://backend");
+    control.bind("inproc://control");
+
+    std::thread t([&]() {
+        one::load_balancer(frontend, backend, control, -1);
+    });
+
+    worker1.connect("inproc://backend");
+    worker2.connect("inproc://backend");
+    client.connect("inproc://frontend");
+    controller.connect("inproc://control");
+
+    SECTION("Workers can fetch tasks that are queued before task-fetch") {
+        task().send(client);
+        task().send(client);
+
+        worker1.send(zmq::message_t(), zmq::send_flags::none);
+        auto result = zmq::multipart_t(worker1);
+        CHECK(result[0].to_string() == "part1");
+        CHECK(result[1].to_string() == "part2");
+
+        worker2.send(zmq::message_t(), zmq::send_flags::none);
+        result = zmq::multipart_t(worker2);
+        CHECK(result[0].to_string() == "part1");
+        CHECK(result[1].to_string() == "part2");
+
+        controller.send(zmq::message_t(""), zmq::send_flags::none);
+        t.join();
+    }
+
+    SECTION("Jobs arriving on queue are passed to waiting workers") {
+        worker1.send(zmq::message_t(), zmq::send_flags::none);
+        worker2.send(zmq::message_t(), zmq::send_flags::none);
+
+        task().send(client);
+        auto result = zmq::multipart_t(worker1);
+        CHECK(result[0].to_string() == "part1");
+        CHECK(result[1].to_string() == "part2");
+
+        task().send(client);
+        result = zmq::multipart_t(worker2);
+        CHECK(result[0].to_string() == "part1");
+        CHECK(result[1].to_string() == "part2");
+
+        controller.send(zmq::message_t(""), zmq::send_flags::none);
+        t.join();
+    }
+}


### PR DESCRIPTION
Message broker that will distribute tasks to workers as they become
available.

The advantage of this approach over PUSH-PULL is that jobs are sent to
idle workers, whereas PUSH-PULL distributes round robin. A disadvantage
is that the queue becomes a single point of failure, and a single point
for all messages to pass through, while PUSH-PULL is N-to-N.