### PR TITLE
Add load balancing message broker

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(oneseismic
     src/worker.cpp
     src/manifest.cpp
     src/messages.cpp
+    src/load_balancer.cpp
 )
 add_library(oneseismic::oneseismic ALIAS oneseismic)
 target_include_directories(oneseismic
@@ -163,6 +164,7 @@ add_executable(tests
     tests/geometry.cpp
     tests/azure-transfer-config.cpp
     tests/messages.cpp
+    tests/load_balancer.cpp
 )
 target_link_libraries(tests
     PRIVATE

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -109,6 +109,7 @@ target_link_libraries(oneseismic-manifest
     fmt::fmt
     PkgConfig::zmq
     clara
+    Threads::Threads
 )
 
 add_executable(oneseismic-fragment

--- a/core/include/oneseismic/load_balancer.hpp
+++ b/core/include/oneseismic/load_balancer.hpp
@@ -1,0 +1,31 @@
+#include <vector>
+
+#ifndef ONESEISMIC_LOAD_BALANCER_HPP
+#define ONESEISMIC_LOAD_BALANCER_HPP
+
+namespace one {
+
+[[noreturn]] void load_balancer(
+    zmq::socket_t& frontend,
+    zmq::socket_t& backend,
+    int ready_ttl);
+
+namespace detail { namespace load_balancer {
+
+struct worker {
+    std::string identity;
+    std::time_t expiry;
+};
+
+void run(
+    zmq::socket_t& frontend,
+    zmq::socket_t& backend,
+    std::vector< worker >& available_workers,
+    int ready_ttl,
+    std::time_t current_time);
+
+}}
+
+}
+
+#endif //ONESEISMIC_LOAD_BALANCER_HPP

--- a/core/src/load_balancer.cpp
+++ b/core/src/load_balancer.cpp
@@ -1,0 +1,141 @@
+#include <algorithm>
+#include <ctime>
+#include <vector>
+#include <spdlog/spdlog.h>
+#include <zmq.hpp>
+#include <zmq_addon.hpp>
+
+#include <oneseismic/load_balancer.hpp>
+
+namespace {
+
+using worker = one::detail::load_balancer::worker;
+
+void update_worker(
+    std::vector< worker >& workers,
+    const std::string& identity,
+    const std::time_t expiry
+) noexcept (false) {
+    auto w = std::find_if(
+        std::begin(workers),
+        std::end(workers),
+        [&identity] (auto item) { return item.identity == identity; }
+    );
+
+    if (w == workers.end())
+        workers.push_back(worker{identity, expiry});
+    else
+        w->expiry = expiry;
+}
+
+void purge_workers(
+    std::vector< worker >& workers,
+    std::time_t current_time
+) noexcept (false) {
+    auto expired = [current_time](auto& worker) {
+        return worker.expiry < current_time;
+    };
+
+    workers.erase(
+        std::remove_if(workers.begin(), workers.end(), expired),
+        workers.end()
+    );
+}
+
+}
+
+namespace one {
+
+namespace detail { namespace load_balancer {
+
+void run(
+    zmq::socket_t& frontend,
+    zmq::socket_t& backend,
+    std::vector< worker >& available_workers,
+    int ready_ttl,
+    std::time_t current_time
+) noexcept (false) {
+
+    zmq::pollitem_t items[] = {
+            {static_cast< void* >(backend),  0, ZMQ_POLLIN, 0},
+            {static_cast< void* >(frontend), 0, ZMQ_POLLIN, 0}
+    };
+
+    /*
+     * Poll frontend only if there are available workers
+     */
+    if (!available_workers.empty())
+        zmq::poll(items, 2, ready_ttl);
+    else
+        zmq::poll(items, 1, ready_ttl);
+
+    // Handle worker control messages from backend
+    if (items[0].revents & ZMQ_POLLIN) {
+        auto msg = zmq::multipart_t(backend);
+        auto expiry = current_time + ready_ttl;
+
+        auto identity = msg[0].to_string();
+        auto message  = msg[1].to_string();
+
+        if (message == "READY")
+            update_worker(available_workers, identity, expiry);
+        else
+            spdlog::error("Invalid message from worker: {}", message);
+    }
+
+    /*
+     * Push message from frontend to available worker.
+     */
+    if (items[1].revents & ZMQ_POLLIN) {
+        auto task = zmq::multipart_t(frontend);
+        auto identity = available_workers[0].identity;
+        available_workers.erase(available_workers.begin());
+        task.pushstr(identity);
+        task.send(backend);
+    }
+
+    purge_workers(available_workers, current_time);
+}
+
+}}
+
+[[noreturn]] void load_balancer(
+    zmq::socket_t& frontend,
+    zmq::socket_t& backend,
+    int ready_ttl
+) {
+    /*
+     * Message broker that will distribute tasks to workers as they become
+     * available.
+     *
+     * This solution is based on the Robust Reliable Queuing (Paranoid Pirate
+     * Pattern) [1], with some key differences:
+     *
+     *     1. Replies from workers are not routed back to the client. Since the
+     *        workers don't send a reply when the job is done, a READY message
+     *        is sent instead, indicating that the worker is available to
+     *        receive new tasks.
+     *     2. Tasks arrive on a PULL socket.
+     *
+     * The advantage of this approach over PUSH-PULL is that jobs are sent to
+     * idle workers, whereas PUSH-PULL distributes round robin. A disadvantage
+     * is that the queue becomes a single point of failure, and a single point
+     * for all messages to pass through, while PUSH-PULL is N-to-N.
+     *
+     * [1] https://zguide.zeromq.org/docs/chapter4/
+     */
+
+    std::vector< worker > available_workers;
+
+    while (true) {
+        detail::load_balancer::run(
+            frontend,
+            backend,
+            available_workers,
+            ready_ttl,
+            std::time(nullptr)
+        );
+    }
+}
+
+}

--- a/core/tests/load_balancer.cpp
+++ b/core/tests/load_balancer.cpp
@@ -1,0 +1,107 @@
+#include <catch/catch.hpp>
+#include <ctime>
+#include <zmq.hpp>
+#include <zmq_addon.hpp>
+
+#include <oneseismic/load_balancer.hpp>
+
+static constexpr int HEARTBEAT_INTERVAL = 10;
+
+namespace {
+
+using worker = one::detail::load_balancer::worker;
+
+zmq::multipart_t task() {
+    zmq::multipart_t task;
+    task.addstr("part1");
+    task.addstr("part2");
+    return task;
+}
+
+}
+
+TEST_CASE("Messages are pushed through to available workers") {
+    zmq::context_t ctx;
+    zmq::socket_t client(ctx, ZMQ_PUSH);
+    zmq::socket_t worker1(ctx, ZMQ_DEALER);
+    zmq::socket_t worker2(ctx, ZMQ_DEALER);
+    zmq::socket_t queue_frontend(ctx, ZMQ_PULL);
+    zmq::socket_t queue_backend(ctx, ZMQ_ROUTER);
+
+    queue_frontend.bind("inproc://queue_frontend");
+    queue_backend.bind("inproc://queue_backend");
+    worker1.connect("inproc://queue_backend");
+    worker2.connect("inproc://queue_backend");
+    client.connect("inproc://queue_frontend");
+
+    std::vector< worker > available_workers;
+
+    auto load_balancer_run = [&] (
+            int ready_ttl,
+            std::time_t time
+    ) {
+        one::detail::load_balancer::run(
+                queue_frontend,
+                queue_backend,
+                available_workers,
+                ready_ttl,
+                time
+        );
+    };
+
+    auto ready = []() {
+        return zmq::message_t(std::string("READY"));
+    };
+
+    SECTION("Job is passed to available worker") {
+        int ready_ttl = 1000;
+        std::time_t time = 1000;
+
+        worker1.send(ready(), zmq::send_flags::none);
+        load_balancer_run(ready_ttl, time);
+        task().send(client);
+        load_balancer_run(ready_ttl, time);
+
+        auto result = zmq::multipart_t(worker1);
+        CHECK(result[0].to_string() == "part1");
+        CHECK(result[1].to_string() == "part2");
+    }
+
+    SECTION("Worker is removed from pool if it has not sent a new READY "
+            "message within ready_ttl") {
+        int ready_ttl = 1000;
+        std::time_t time = 1000;
+
+        worker1.send(ready(), zmq::send_flags::none);
+        load_balancer_run(ready_ttl, time);
+        load_balancer_run(
+            ready_ttl,
+            time + ready_ttl + 1
+        );
+
+        CHECK(available_workers.empty());
+    }
+
+    SECTION("Worker is *not* removed from pool when new READY is received "
+            "within ready_ttl interval") {
+        int ready_ttl = 1000;
+        std::time_t time = 1000;
+
+        worker1.send(ready(), zmq::send_flags::none);
+        worker2.send(ready(), zmq::send_flags::none);
+        load_balancer_run(ready_ttl, time);
+        load_balancer_run(ready_ttl, time);
+        worker1.send(ready(), zmq::send_flags::none);
+        load_balancer_run(
+            ready_ttl,
+            time + ready_ttl
+        );
+        load_balancer_run(
+            ready_ttl,
+            time + ready_ttl + 1
+        );
+
+        CHECK(available_workers.size() == 1);
+    }
+
+}


### PR DESCRIPTION
Message broker that will distribute tasks to workers as they become
available.

The advantage of this approach over PUSH-PULL is that jobs are sent to
idle workers, whereas PUSH-PULL distributes round robin. A disadvantage
is that the queue becomes a single point of failure, and a single point
for all messages to pass through, while PUSH-PULL is N-to-N.