### PR TITLE
Update login.py with recursive folder creation

### DIFF
--- a/python/oneseismic/login/login.py
+++ b/python/oneseismic/login/login.py
@@ -184,7 +184,7 @@ class tokens:
         >>> oneseismic.ls(session)
         ['038855', '0d235a']
         """
-        pathlib.Path(self.root).mkdir(exist_ok = True)
+        os.makedirs(pathlib.Path(self.root), exist_ok = True)
 
         cache = self.cache()
         app = msal.PublicClientApplication(


### PR DESCRIPTION
In the case that the base cache folder does not exists the current folder creation will fail as it is not recursive. Using os.makedirs with exist_ok=True fixes this issue without introducing additional dependencies.

This is a duplicate of #425 with updated commit messages