### PR TITLE
Replace partial result keys with redis stream

### DIFF
--- a/api/cmd/query/main.go
+++ b/api/cmd/query/main.go
@@ -225,7 +225,8 @@ func main() {
 
 	results := app.Group("/result")
 	results.Use(auth.ResultAuth(&keyring))
-	results.GET("/:pid",        result.Get)
+	results.GET("/:pid", result.Get)
+	results.GET("/:pid/stream", result.Stream)
 	results.GET("/:pid/status", result.Status)
 
 	app.GET("/config", cfg.Get)


### PR DESCRIPTION
Store results in redis as a single stream data structure rather than as
individual keys for each partial result. This has several benefits:

  1. Stream offers blocking operations for waiting for results to be
     ready
  2. Dealing with a single datastructure for monitoring progress is more
     ergonomic
  3. Tests showed that stream performed better under high loads with
     many workers writing partial results to storage concurrently.