### PR TITLE
Blobfs sas token auth

### DIFF
--- a/python/oneseismic/__init__.py
+++ b/python/oneseismic/__init__.py
@@ -1,1 +1,7 @@
+try:
+    import pkg_resources
+    __version__ = pkg_resources.get_distribution(__name__).version
+except pkg_resources.DistributionNotFound:
+    pass
+
 from . import client

--- a/python/oneseismic/internal/argparse.py
+++ b/python/oneseismic/internal/argparse.py
@@ -53,9 +53,9 @@ def blobfs_from_args(url, method, connstr, creds):
     Instead, it is simple automation on how the arguments are interpreted, with
     fallbacks and exclusive options.
 
-    If a method is explicitly specified, that method willfor authentication. If
-    a no method is specified, and either the connection-string or the
-    credentials are specified, then that method will be used.  If neither
+    If a method is explicitly specified, that method will be used for
+    authentication. If no method is specified, and either the connection-string
+    or the credentials are specified, then that method will be used. If neither
     method, connection string, nor credentials are specified, it is assumed it
     is encoded in the URL. See the docs [1]_ for the blob client.
 

--- a/python/oneseismic/internal/argparse.py
+++ b/python/oneseismic/internal/argparse.py
@@ -13,6 +13,9 @@ from urllib.parse import urlunparse
 from .blobfs import blobfs
 from .localfs import localfs
 
+class NotUrlError(ValueError):
+    pass
+
 def add_auth_args(parser, direction):
     """
     """
@@ -122,7 +125,7 @@ def blobfs_from_args(url, method, connstr, creds):
     if method in ['url', 'credentials']:
         parsed = urlparse(url)
         if parsed.scheme not in ['http', 'https']:
-            raise ValueError('not a blob url')
+            raise NotUrlError('not a blob url')
 
         # If the credentials are encoded in the URL, either as a SAS token or a
         # URL-encoded account key, then creds should be None anyway, and the

--- a/python/oneseismic/internal/argparse.py
+++ b/python/oneseismic/internal/argparse.py
@@ -126,22 +126,7 @@ def blobfs_from_args(url, method, connstr, creds):
         parsed = urlparse(url)
         if parsed.scheme not in ['http', 'https']:
             raise NotUrlError('not a blob url')
-
-        # If the credentials are encoded in the URL, either as a SAS token or a
-        # URL-encoded account key, then creds should be None anyway, and the
-        # case of url-encoded and explicit credentials end up being the same
-
-        # Only keep the first part of the path, in case it specifies the
-        # container and blob.
-        unparsed = (
-            parsed.scheme,
-            parsed.netloc,
-            '/'.join(parsed.path.split('/')[:2]),
-            parsed.params,
-            parsed.query,
-            parsed.fragment
-        )
-        return blobfs.from_url(urlunparse(unparsed), credential = creds)
+        return blobfs.from_url(url, credential = creds)
     elif method == 'connection-string':
         return blobfs.from_connection_string(connstr)
     else:

--- a/python/oneseismic/internal/blobfs.py
+++ b/python/oneseismic/internal/blobfs.py
@@ -158,7 +158,7 @@ class blobfs:
 
     @staticmethod
     def from_url(url, credential):
-        """Init filesystem from account URL
+        """Init filesystem from an URL
 
         Initialize a virtual blob filesystem based on an account URL and a
         credential. The credential can be a connection string or a shared

--- a/python/oneseismic/scan/__main__.py
+++ b/python/oneseismic/scan/__main__.py
@@ -10,6 +10,7 @@ from ..internal.argparse import add_auth_args
 from ..internal.argparse import blobfs_from_args
 from ..internal.argparse import localfs_from_args
 from ..internal.argparse import get_blob_path
+from ..internal.argparse import NotUrlError
 
 def main(argv):
     parser = argparse.ArgumentParser(
@@ -40,7 +41,7 @@ def main(argv):
         container, blob = get_blob_path(args.src)
         inputfs.cd(container)
         src = blob
-    except ValueError:
+    except NotUrlError:
         inputfs = localfs_from_args(args.src)
         src = args.src
 

--- a/python/oneseismic/upload/__main__.py
+++ b/python/oneseismic/upload/__main__.py
@@ -12,6 +12,7 @@ from ..internal.argparse import blobfs_from_args
 from ..internal.argparse import localfs_from_args
 from ..internal.argparse import add_auth_args
 from ..internal.argparse import get_blob_path
+from ..internal.argparse import NotUrlError
 
 def main(argv):
     parser = argparse.ArgumentParser(
@@ -81,7 +82,7 @@ def main(argv):
         container, blob = get_blob_path(args.src)
         inputfs.cd(container)
         src = blob
-    except ValueError:
+    except NotUrlError:
         inputfs = localfs_from_args(args.src)
         src = args.src
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -5,7 +5,7 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 license = AGPL-3.0
 url = https://github.com/equinor/oneseismic
-version = 0.1.7
+version = 0.1.8
 
 [options]
 packages =


### PR DESCRIPTION
Scan and upload learnt to read input volumes as https://acc.storage/container/blob?sas=token, and supports single-blob signatures.