### PR TITLE
Dispatch tasks on redis stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN make -j4 install
 
 FROM golang:1.15-buster as gobuilder
 COPY --from=cppbuilder /usr/local /usr/local
-RUN apt-get update && apt-get install -y libzmq5-dev
+RUN apt-get update && apt-get install -y libzmq5-dev nlohmann-json3-dev
 
 WORKDIR /src
 COPY api/go.mod .

--- a/api/api/slice.cpp
+++ b/api/api/slice.cpp
@@ -1,0 +1,136 @@
+#include "slice.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <oneseismic/geometry.hpp>
+#include <oneseismic/messages.hpp>
+
+/*
+ * Right now the implementation is a straight-up copy from the
+ * core/src/manifest.cpp file, in order to more quickly and easily develop and
+ * experiment with redis streams rather than ZMQ for job scheduling. The design
+ * and implementation is likely to evolve rapidly from here.
+ */
+namespace {
+
+one::gvt< 3 > geometry(
+        const nlohmann::json& dimensions,
+        const nlohmann::json& shape) noexcept (false) {
+    return one::gvt< 3 > {
+        { dimensions[0].size(),
+          dimensions[1].size(),
+          dimensions[2].size(), },
+        { shape[0].get< std::size_t >(),
+          shape[1].get< std::size_t >(),
+          shape[2].get< std::size_t >(), }
+    };
+}
+
+one::slice_fetch build_slice_fetch(
+        const one::slice_task& task,
+        const nlohmann::json& manifest)
+noexcept (false) {
+    auto out = one::slice_fetch(task);
+
+    /*
+     * TODO:
+     * faster to not make vector, but rather parse-and-compare individual
+     * integers?
+     */
+    const auto& manifest_dimensions = manifest["dimensions"];
+    const auto index = manifest_dimensions[task.dim].get< std::vector< int > >();
+    const auto itr = std::find(index.begin(), index.end(), task.lineno);
+    if (itr == index.end()) {
+        const auto msg = "line (= {}) not found in index";
+        throw std::invalid_argument(fmt::format(msg, task.lineno));
+    }
+
+    const auto pin = std::distance(index.begin(), itr);
+    auto gvt = geometry(manifest_dimensions, task.shape);
+
+    // TODO: name loop
+    for (const auto& dimension : manifest_dimensions)
+        out.cube_shape.push_back(dimension.size());
+
+    const auto to_vec = [](const auto& x) {
+        return std::vector< int > { int(x[0]), int(x[1]), int(x[2]) };
+    };
+
+    out.lineno = pin % gvt.fragment_shape()[task.dim];
+    const auto ids = gvt.slice(one::dimension< 3 >(task.dim), pin);
+    // TODO: name loop
+    for (const auto& id : ids)
+        out.ids.push_back(to_vec(id));
+    return out;
+}
+
+template < typename T >
+void* copyalloc(const T& x) {
+    void* p = std::malloc(x.size() * sizeof(*x.data()));
+    std::memcpy(p, x.data(), x.size());
+    return p;
+}
+
+std::size_t task_count(std::size_t jobs, std::size_t task_size) {
+    /*
+     * Return the number of task-size'd tasks needed to process all jobs
+     */
+    return (jobs + (task_size - 1)) / task_size;
+}
+
+}
+
+tasks* mkschedule(const char* doc, int len, int task_size) {
+    one::slice_task request;
+    request.unpack(doc, doc + len);
+    const auto manifest = nlohmann::json::parse(request.manifest);
+
+    auto fetch = build_slice_fetch(request, manifest);
+    const auto ids = fetch.ids;
+
+    const auto ntasks = task_count(ids.size(), task_size);
+    auto first = ids.begin();
+    auto end = ids.end();
+
+    struct deleter {
+        void operator () (tasks* t) noexcept (true) {
+            cleanup(t);
+        }
+    };
+
+    std::unique_ptr< tasks, deleter > cs(new tasks());
+    cs->err = nullptr;
+    cs->tasks = new task[ntasks];
+    cs->size = ntasks;
+    for (std::size_t i = 0; i < ntasks; ++i) {
+        if (first == end)
+            break;
+
+        auto& task = cs->tasks[i];
+        auto last = std::min(first + task_size, end);
+
+        fetch.ids.assign(first, last);
+        std::advance(first, fetch.ids.size());
+        auto packed = fetch.pack();
+        task.size  = packed.size();
+        task.task = copyalloc(packed);
+    }
+
+    return cs.release();
+}
+
+void cleanup(tasks* cs) {
+    if (!cs) return;
+
+    for (int i = 0; i < cs->size; ++i) {
+        std::free((void*)cs->tasks[i].task);
+    }
+    delete cs->err;
+    delete cs->tasks;
+    delete cs;
+}

--- a/api/api/slice.h
+++ b/api/api/slice.h
@@ -1,0 +1,25 @@
+#ifndef ONESEISMIC_CGO_SLICE_H
+#define ONESEISMIC_CGO_SLICE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
+struct task {
+    int size;
+    const void* task;
+};
+
+struct tasks {
+    const char* err;
+    int size;
+    struct task* tasks;
+};
+
+struct tasks* mkschedule(const char* doc, int len, int task_size);
+void cleanup(struct tasks*);
+
+#ifdef __cplusplus
+}
+#endif //__cplusplus
+#endif //ONESEISMIC_CGO_SLICE_H

--- a/api/cmd/fetch/fetch.go
+++ b/api/cmd/fetch/fetch.go
@@ -254,7 +254,7 @@ func (p *process) container() (azblob.ContainerURL, error) {
  * This function finalizes the process.
  */
 func (p *process) gather(
-	storage    *redis.Client,
+	storage    redis.Cmdable,
 	nfragments int,
 	fragments  chan fragment,
 	errors     chan error,

--- a/api/cmd/fetch/main.go
+++ b/api/cmd/fetch/main.go
@@ -1,33 +1,28 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
-	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/go-redis/redis/v8"
 	"github.com/pborman/getopt/v2"
-	"github.com/pebbe/zmq4"
 )
 
 type opts struct {
-	source    string
 	redis     string
-	heartbeat time.Duration
+	group     string
+	stream    string
 	jobs      int
 }
 
 func parseopts() opts {
 	help := getopt.BoolLong("help", 0, "print this help text")
-	opts := opts {}
-	getopt.FlagLong(
-		&opts.source,
-		"source",
-		's',
-		"Address to source, e.g. tcp://host[:port]",
-		"addr",
-	).Mandatory()
+	opts := opts {
+		group:  "fetch",
+		stream: "jobs",
+	}
 	getopt.FlagLong(
 		&opts.redis,
 		"redis",
@@ -35,12 +30,23 @@ func parseopts() opts {
 		"Address to redis, e.g. host[:port]",
 		"addr",
 	).Mandatory()
-	heartbeat := getopt.DurationLong(
-		"heartbeat",
-		'H',
-		60 * time.Second,
-		"time between READY messages to source",
-		"interval",
+	getopt.FlagLong(
+		&opts.group,
+		"group",
+		'G',
+		"Consumer group. " +
+		    "All workers should belong to the same group for " +
+		    "fair distribution of work. " +
+		    "You should normally not need to change this.",
+		"name",
+	)
+	getopt.FlagLong(
+		&opts.stream,
+		"stream",
+		'S',
+		"Stream ID to read tasks from. Must be consistent with the producer. " +
+		    "You should normally not need to change this.",
+		"name",
 	)
 	jobs := getopt.IntLong(
 		"jobs",
@@ -56,7 +62,6 @@ func parseopts() opts {
 		os.Exit(0)
 	}
 
-	opts.heartbeat = *heartbeat
 	opts.jobs = *jobs
 	return opts
 }
@@ -66,18 +71,66 @@ type task struct {
 	blob  azblob.BlobURL
 }
 
+func run(
+	storage redis.Cmdable,
+	njobs   int,
+	process map[string]interface{},
+) {
+	/*
+	 * Curiously, the XReadGroup/XStream values end up being map[string]string
+	 * effectively. This is detail of the go library where it uses ReadLine()
+	 * internally - redis uses byte strings as strings anyway.
+	 *
+	 * The type assertion is not checked and will panic. This is a good thing
+	 * as it should only happen when the redis library is updated to no longer
+	 * return strings, and crash oneseismic properly. This should catch such a
+	 * change early.
+	 */
+	pid  := process["pid" ].(string)
+	part := process["part"].(string)
+	body := process["task"].(string)
+	msg  := [][]byte{ []byte(pid), []byte(part), []byte(body) }
+	proc, err := exec(msg)
+	if err != nil {
+		log.Printf("%s dropping bad process %v", proc.logpid(), err)
+		return
+	}
+	/*
+	 * Build the container-URL early, in case it should be broken,
+	 * so that no goroutines are scheduled before any sanity
+	 * checking of input.
+	 */
+	container, err := proc.container()
+	if err != nil {
+		log.Printf("%s dropping bad process %v", proc.logpid(), err)
+		return
+	}
+
+	// TODO: share job queue between processes, but use private
+	// output/error queue? Then buffered-elements would control
+	// number of pending jobs Rather than it now continuing once
+	// the last task has been scheduled and possibly spawning N
+	// more goroutines.
+	frags  := make(chan fragment)
+	tasks  := make(chan task)
+	errors := make(chan error)
+	/*
+	 * The goroutines must be signalled that there are no more data, or
+	 * they will leak.
+	 */
+	defer close(tasks)
+	for i := 0; i < njobs; i++ {
+		go fetch(proc.ctx, tasks, frags, errors)
+	}
+	fragments := proc.fragments()
+	go proc.gather(storage, len(fragments), frags, errors)
+	for i, id := range fragments {
+		tasks <- task { index: i, blob: container.NewBlobURL(id) }
+	}
+}
+
 func main() {
 	opts := parseopts()
-
-	source, err := zmq4.NewSocket(zmq4.DEALER)
-	if err != nil {
-		log.Fatalf("Unable to create socket: %v", err)
-	}
-	err = source.Connect(opts.source)
-	if err != nil {
-		log.Fatalf("Unable to connect queue to %s: %v", opts.source, err)
-	}
-	defer source.Close()
 
 	storage := redis.NewClient(&redis.Options {
 		Addr: opts.redis,
@@ -86,106 +139,57 @@ func main() {
 	// TODO: err?
 	defer storage.Close()
 
-	poll := zmq4.NewPoller()
-	poll.Add(source, zmq4.POLLIN)
+	ctx := context.Background()
+	/*
+	 * Always try to create the group and stream on start-up. The stream may
+	 * have already been created, but that is a soft error to be discarded. In
+	 * fact, the stream and group *probably* exists already because nodes
+	 * connect in parallel.
+	 *
+	 * The XGroupCreate command is really just a try-create and fits well here,
+	 * it offloads all the concurrency issues to redis. Consequently, this
+	 * program can immediately go into the work loop assuming that the stream
+	 * and group exists, without having to do any chatter or sync.
+	 */
+	// TODO: check-err, fail on hard errors
+	storage.XGroupCreateMkStream(ctx, opts.stream, opts.group, "0")
+
+	// TODO: destroy consumers on shutdown
+	// All reads can re-use the same group-args
+	// NoAck is turned on - we can afford to fail requests and lose messages
+	// should a node crash.
+	args := redis.XReadGroupArgs {
+		Group:    opts.group,
+		Consumer: "consumer-id", // derive-from-node
+		Streams:  []string { opts.stream, ">", },
+		Count:    1,
+		NoAck:    true,
+	}
+
 	for {
-		/*
-		 * There should only be new assignments after a READY message is sent,
-		 * so it should be performed unconditionally at the start of the loop.
-		 */
-		_, err := source.Send("READY", 0)
+		msgs, err := storage.XReadGroup(ctx, &args).Result()
 		if err != nil {
-			switch zmq4.AsErrno(err) {
-				/*
-				 * Add handlers for recoverable errors here
-				 */
-			}
-
-			/*
-			 * Take down the service if the source socket breaks. This is a bit
-			 * heavy handed, but I have no good grasp right now on what might
-			 * go wrong or is recoverable, so the right call is to promptly
-			 * kill anything that breaks the socket and fix issues when they
-			 * come up.
-			 *
-			 * There should be an automated log alert for this error.
-			 */
-			log.Fatalf("socket broken: %v", err)
-		}
-
-		active, err := poll.Poll(opts.heartbeat)
-		if err != nil {
-			/*
-			 * Take down the service if the poll breaks. This is a bit heavy
-			 * handed, but I have no good grasp right now on what might go
-			 * wrong, and what is recoverable, so the right call is to properly
-			 * kill anything that breaks and fix issues as they come up.
-			 *
-			 * There should be an automated log alert for this error.
-			 */
-			log.Fatalf("poll broken: %v", err)
+			log.Fatalf("Unable to read from redis: %v", err)
 		}
 
 		/*
-		 * Process pending requests
+		 * The redis interface is designed for asking for a set of messages per
+		 * XReadGroup command, but we really only ask for one [1]. The redis-go
+		 * API is is aware of this which means the message structure must be
+		 * unpacked with nested loops. As a consequence, the read-count can
+		 * be increased with little code change, but it also means more nested
+		 * loops.
 		 *
-		 * There's some syntactical noise here with the range-of-sockets and
-		 * then switch. It is quite unnecessary for as long as there's only one
-		 * queue in use, but there's a high probability there will be more, and
-		 * with for-all infrastructure set up it should be easy to integrate
-		 * new handlers into the loop.
+		 * For ease of understanding, the loops can be ignored.
+		 *
+		 * [1] Instead opting for multiple fragments to download per message.
+		 *     This is a design decision from before redis streams, but it
+		 *     works well with redis streams too.
 		 */
-		for _, socket := range active {
-			switch s := socket.Socket; s {
-			case source:
-				msg, err := source.RecvMessageBytes(0)
-				if err != nil {
-					log.Fatalf("recvmessage broken: %v", err)
-				}
-				proc, err := exec(msg)
-				if err != nil {
-					log.Printf("%s dropping bad process %v", proc.logpid(), err)
-					break
-				}
-				/*
-				 * Build the container-URL early, in case it should be broken,
-				 * so that no goroutines are scheduled before any sanity
-				 * checking of input.
-				 */
-				container, err := proc.container()
-				if err != nil {
-					log.Printf("%s dropping bad process %v", proc.logpid(), err)
-					break
-				}
-				log.Printf("%s being processed", proc.logpid())
-				// TODO: share job between processes, but private use
-				// output/error queue? Then buffered-elements would control
-				// number of pending jobs Rather than it now continuing once
-				// the last task has been scheduled and possibly spawning N
-				// more goroutines.
-				frags  := make(chan fragment)
-				tasks  := make(chan task)
-				errors := make(chan error)
-				for i := 0; i < opts.jobs; i++ {
-					go fetch(proc.ctx, tasks, frags, errors)
-				}
-				fragments := proc.fragments()
-				go proc.gather(storage, len(fragments), frags, errors)
-				for i, id := range fragments {
-					tasks <- task { index: i, blob: container.NewBlobURL(id) }
-				}
-				/*
-				 * The goroutines must be signalled that there are no more
-				 * data, or they will leak. defer close() cannot be used since
-				 * it works on a function scope, unless the rest of the body is
-				 * wrapped in a func(){}()
-				 *
-				 * https://stackoverflow.com/questions/49456943/why-is-golang-defer-scoped-to-function-not-lexical-enclosure
-				 */
-				close(tasks)
-
-			default:
-				log.Fatalf("unhandled message: %v", s)
+		for _, xmsg := range msgs {
+			for _, message := range xmsg.Messages {
+				// TODO: graceful shutdown and/or cancellation
+				run(storage, opts.jobs, message.Values)
 			}
 		}
 	}

--- a/api/cmd/query/main.go
+++ b/api/cmd/query/main.go
@@ -191,7 +191,13 @@ func main() {
 	defer out.Close()
 
 	keyring := auth.MakeKeyring([]byte(opts.signkey))
-	slice := api.MakeSlice(&keyring, opts.storageURL, out)
+	cmdable := redis.NewClient(
+		&redis.Options {
+			Addr: opts.redisURL,
+			DB: 0,
+		},
+	)
+	slice := api.MakeSlice(&keyring, opts.storageURL, out, cmdable)
 	result := api.Result {
 		Timeout: time.Second * 15,
 		StorageURL: opts.storageURL,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,7 @@ services:
       dockerfile: Dockerfile
     command: [
         "oneseismic-fetch",
-        "--source", "tcp://manifest:6142",
         "--redis",  "storage:6379",
-        "--heartbeat", "60s",
     ]
     depends_on:
       - storage


### PR DESCRIPTION
This is a first step in a re-design of the task distribution to use
redis streams rather than ZMQ.

Context
-------
For a long time, there has been an issue with the messages queues - they
would silently stall after a long period of inactivity, without any
party recognising it. The culprit is the TCP connection being dropped on
either side of the API <-> scheduler <-> worker boundary, and neither
application is aware.

The situation improved when the scheduler got its pull-based
ready-for-work design, but the connection between the API servers and
the scheduler would still break. This manifested as jobs being "passed
on" from the API server, but the scheduler never receiving the job. This
was mitigated by setting TCP-keepalive and ZMQ heartbeating, but it is
not sufficient for a robust design.

This is expected behaviour with ZMQ, and makes some sense - even without
TCP connections sliently being dropped, the applications need to be
aware of the state of the (immediate) peers for all sorts of robustness
and scaling reasons, especially with workers coming-and-going.

Leading up to this, I have done several experiments with keep-alive and
heartbeating between nodes. The implementation does not end up being so
bad, but naturally handling this robustly means a non-trivial amount of
code. Moving beyond the problem of connections silently dropping,
there's the issue of dynamic scaling, in particular of workers.

Enter redis
-----------
After some exploration of the greater issue, redis pops up again. Redis
comes with built-in support for fan-out work scheduling through its
stream and consumer groups features, which is exactly what the
scheduler/oneseismic-manifest program implemented.

This comes with a long list of benefits:

  - redis can be in charge of scaling, with replicas and what-not
  - the connection keep-alive problem is handed off to redis
  - new clients can easily join the worker pool with a single redis
    connect()
  - the stream can be audited with generic tools
  - the custom scheduler program stops existing

This means that the task queue is managed by redis, and the fetch client
is implemented with a simple redis blocking read.

The implementation
------------------
This patch moves the request -> task-set mapping to the API node, and
re-wires the fetch program to pull from redis rather than ZMQ,
eliminating the server-manifest altogether. No protocol or format
changes are introduced, only the transport has changed.

The creation of chunks-of-work objects is done in C++ (as it relies on
deep understanding of the geometry), but invoked from Go. This builds on
the pattern established by fetch, where Go is responsible for the
main-loop and I/O, and C++ understands the geometry and provides the
data.

The Go programs effectively run the C++ code as separate programs and
parse the output, but now that Go directly invoke C++ then there are
good opportunities for refactoring. No refactoring is done in this
patch, in order to make reverts and merges easier.