### PR TITLE
Respect root argument when making localfs

### DIFF
--- a/python/oneseismic/internal/argparse.py
+++ b/python/oneseismic/internal/argparse.py
@@ -136,11 +136,7 @@ def localfs_from_args(path):
     if path is None:
         path = Path()
     path = Path(path)
-    if path.is_absolute():
-        root = Path('/')
-    else:
-        root = Path('.')
-    return localfs(root)
+    return localfs(path)
 
 def get_blob_path(url):
     """

--- a/python/oneseismic/internal/test_argparse.py
+++ b/python/oneseismic/internal/test_argparse.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+from .argparse import localfs_from_args
+
+def test_localfs_root_from_args():
+    assert localfs_from_args(None).root   == Path('.')
+    assert localfs_from_args('/usr').root == Path('/usr')
+    assert localfs_from_args('rel').root  == Path('.') / Path('rel')


### PR DESCRIPTION
The path/root argument in the localfs-from-args function was effectively
ignored, when it should be considered the root.