### PR TITLE
Graphql endpoint

### DIFF
--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -1,0 +1,387 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/go-redis/redis/v8"
+	"github.com/Azure/azure-storage-blob-go/azblob"
+
+	"github.com/equinor/oneseismic/api/internal/auth"
+	"github.com/equinor/oneseismic/api/internal/message"
+	"github.com/equinor/oneseismic/api/internal/util"
+)
+
+type gql struct {
+	schema *graphql.Schema
+}
+
+type resolver struct {
+	BasicEndpoint
+}
+type cube struct {
+	id       graphql.ID
+	root     *resolver
+	manifest *message.Manifest
+}
+type promise struct {
+	url string
+	key string
+}
+
+func (s *resolver) MakeSliceTask(
+	pid       string,
+	token     string,
+	manifest  []byte,
+	shape     []int32,
+	shapecube []int32,
+	guid      string,
+	dim       int,
+	lineno    int,
+) *message.Task {
+	task := s.BasicEndpoint.MakeTask(
+		pid,
+		guid,
+		token,
+		manifest,
+		shape,
+		shapecube,
+	)
+	task.Function = "slice"
+	task.Params   = &message.SliceParams {
+		Dim:    dim,
+		Lineno: lineno,
+	}
+	return task
+}
+
+func (c *resolver) MakeCurtainTask(
+	pid       string,
+	guid      string,
+	token     string,
+	manifest  []byte,
+	shape     []int32,
+	shapecube []int32,
+	params    *message.CurtainParams,
+) *message.Task {
+	task := c.BasicEndpoint.MakeTask(
+		pid,
+		guid,
+		token,
+		manifest,
+		shape,
+		shapecube,
+	)
+	task.Function = "curtain"
+	task.Params   = params
+	return task
+}
+
+func (r *resolver) Cube(
+	ctx context.Context,
+	args struct { Id graphql.ID },
+) (*cube, error) {
+	keys := ctx.Value("keys").(map[string]string)
+	pid  := keys["pid"]
+	auth := keys["Authorization"]
+
+	manifest, err := getManifest(
+		ctx,
+		r.tokens,
+		r.endpoint,
+		string(args.Id),
+		auth,
+	)
+	if err != nil {
+		log.Printf("pid=%s %v", pid, err)
+		return nil, err
+	}
+
+	return &cube {
+		id:       args.Id,
+		root:     r,
+		manifest: manifest,
+	}, nil
+}
+
+func (c *cube) Id() graphql.ID {
+	return c.id
+}
+
+type sliceargs struct {
+	Kind int32
+	Id   int32
+}
+
+/*
+ * This is the util.GetManifest function, but tuned for graphql and with
+ * gin-specifics removed. Its purpose is to make for a quick migration to a
+ * working graphql interface to oneseismic. Expect this function to be removed
+ * or drastically change soon.
+ */
+func getManifest(
+	ctx      context.Context,
+	tokens   auth.Tokens,
+	endpoint string,
+	guid     string,
+	auth     string,
+) (*message.Manifest, error) {
+	container, err := url.Parse(fmt.Sprintf("%s/%s", endpoint, guid))
+	if err != nil {
+		return nil, err
+	}
+
+	manifest, err := util.WithOnbehalfAndRetry(
+		tokens,
+		auth,
+		func (tok string) (interface{}, error) {
+			return util.FetchManifest(ctx, tok, container)
+		},
+	)
+	if err != nil {
+		switch e := err.(type) {
+		case azblob.StorageError:
+			sc := e.Response()
+			if sc.StatusCode == http.StatusNotFound {
+				// TODO: add guid as a part of the error message?
+				return nil, errors.New("Not found")
+			}
+			return nil, errors.New("Internal error")
+		}
+		return nil, err
+	}
+
+	m, err := util.ParseManifest(manifest.([]byte))
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (c *cube) Slice(
+	ctx context.Context,
+	args sliceargs,
+) (*promise, error) {
+	keys := ctx.Value("keys").(map[string]string)
+	pid  := keys["pid"]
+	auth := keys["Authorization"]
+	/*
+	 * Embedding a json doc as a string works (surprisingly) well, since the
+	 * Pack()/encoding escapes all nested quotes. It might be reasonable at
+	 * some point to change the underlying representation to messagepack, or
+	 * even send the messages gzipped, but so for now strings and embedded
+	 * documents should do fine.
+	 *
+	 * This opens an opportunity for the manifest forwarded not being quite
+	 * faithful to what's stored in blob, i.e. information can be stripped out
+	 * or added.
+	 */
+	token, err := c.root.tokens.GetOnbehalf(auth)
+	if err != nil {
+		// No further recovery is tried - GetManifest should already have fixed
+		// a broken token, so this should be readily cached. If it is
+		// just-about to expire then the process will fail pretty soon anyway,
+		// so just give up.
+		log.Printf("pid=%s, %v", pid, err)
+		return nil, err
+	}
+
+	packedmanifest, err := c.manifest.Pack()
+	if err != nil {
+		log.Printf("pid=%s %v", pid, err)
+		return nil, err
+	}
+
+	cubeshape := make([]int32, 0, len(c.manifest.Dimensions))
+	for i := 0; i < len(c.manifest.Dimensions); i++ {
+		cubeshape = append(cubeshape, int32(len(c.manifest.Dimensions[i])))
+	}
+	msg := c.root.MakeSliceTask(
+		pid,
+		token,
+		packedmanifest,
+		[]int32{ 64, 64, 64 },
+		cubeshape,
+		string(c.id),
+		int(args.Kind),
+		int(args.Id),
+	)
+
+	key, err := c.root.keyring.Sign(pid)
+	if err != nil {
+		log.Printf("pid=%s, %v", pid, err)
+		return nil, err
+	}
+
+	query, err := c.root.sched.MakeQuery(msg)
+	if err != nil {
+		log.Printf("pid=%s, %v", pid, err)
+		return nil, err
+	}
+
+	go func () {
+		err := c.root.sched.Schedule(context.Background(), pid, query)
+		if err != nil {
+			/*
+			 * Make scheduling errors fatal to detect them for debugging.
+			 * Eventually this should log, maybe cancel the process, and
+			 * continue.
+			 */
+			log.Fatalf("pid=%s, %v", pid, err)
+		}
+	}()
+
+	return &promise {
+		url: fmt.Sprintf("result/%s", pid),
+		key: key,
+	}, nil
+}
+
+func toCurtainParams(coords [][]int32) *message.CurtainParams {
+	// TODO: sanity check etc
+	xs := make([]int, len(coords))
+	ys := make([]int, len(coords))
+	for i, xy := range coords {
+		xs[i] = int(xy[0])
+		ys[i] = int(xy[1])
+	}
+	return &message.CurtainParams{ Dim0s: xs, Dim1s: ys }
+}
+
+func (c *cube) Curtain(
+	ctx    context.Context,
+	args   struct { Coords [][]int32 },
+) (*promise, error) {
+	keys := ctx.Value("keys").(map[string]string)
+	pid  := keys["pid"]
+	auth := keys["Authorization"]
+
+	token, err := c.root.tokens.GetOnbehalf(auth)
+	if err != nil {
+		// No further recovery is tried - GetManifest should already have fixed
+		// a broken token, so this should be readily cached. If it is
+		// just-about to expire then the process will fail pretty soon anyway,
+		// so just give up.
+		log.Printf("pid=%s, %v", pid, err)
+		return nil, err
+	}
+
+	packedmanifest, err := c.manifest.Pack()
+	if err != nil {
+		log.Printf("pid=%s %v", pid, err)
+		return nil, err
+	}
+
+	cubeshape := make([]int32, 0, len(c.manifest.Dimensions))
+	for i := 0; i < len(c.manifest.Dimensions); i++ {
+		cubeshape = append(cubeshape, int32(len(c.manifest.Dimensions[i])))
+	}
+	msg := c.root.MakeCurtainTask(
+		pid,
+		string(c.id),
+		token,
+		packedmanifest,
+		[]int32{ 64, 64, 64 },
+		cubeshape,
+		toCurtainParams(args.Coords),
+	)
+
+	key, err := c.root.keyring.Sign(pid)
+	if err != nil {
+		log.Printf("pid=%s, %v", pid, err)
+		return nil, err
+	}
+
+	query, err := c.root.sched.MakeQuery(msg)
+	if err != nil {
+		log.Printf("pid=%s, %v", pid, err)
+		return nil, err
+	}
+
+	go func () {
+		err := c.root.sched.Schedule(context.Background(), pid, query)
+		if err != nil {
+			/*
+			 * Make scheduling errors fatal to detect them for debugging.
+			 * Eventually this should log, maybe cancel the process, and
+			 * continue.
+			 */
+			log.Fatalf("pid=%s, %v", pid, err)
+		}
+	}()
+
+	return &promise {
+		url: fmt.Sprintf("result/%s", pid),
+		key: key,
+	}, nil
+}
+
+func (p *promise) Url() string {
+	return p.url
+}
+
+func (p *promise) Key() string {
+	return p.key
+}
+
+func MakeGraphQL(
+	keyring  *auth.Keyring,
+	endpoint string,
+	storage  redis.Cmdable,
+	tokens   auth.Tokens,
+) *gql {
+	schema := `
+type Query {
+    cube(id: ID!): Cube!
+}
+
+type Cube {
+    id: ID!
+
+    slice(kind: Int!, id: Int!): Promise!
+	curtain(coords: [[Int!]!]!): Promise!
+}
+
+type Promise {
+    url: String!
+    key: String!
+}
+	`
+	resolver := &resolver {
+		MakeBasicEndpoint(
+			keyring,
+			endpoint,
+			storage,
+			tokens,
+		),
+	}
+
+
+	s := graphql.MustParseSchema(schema, resolver)
+	return &gql {
+		schema: s,
+	}
+}
+
+func (g *gql) Get(ctx *gin.Context) {
+	query  := ctx.Query("query")
+	opName := ctx.Query("operationName")
+
+	// TODO: parse the ?variables=... to this map
+	//variables := ctx.Query("variables")
+	variables := make(map[string]interface{})
+
+	keys := map[string]string {
+		"pid": ctx.GetString("pid"),
+		"Authorization": ctx.GetHeader("Authorization"),
+	}
+	c := context.WithValue(ctx, "keys", keys)
+	res := g.schema.Exec(c, query, opName, variables)
+	ctx.JSON(200, res)
+}

--- a/api/cmd/query/main.go
+++ b/api/cmd/query/main.go
@@ -226,7 +226,8 @@ func main() {
 
 	graphql := app.Group("/graphql")
 	graphql.Use(util.GeneratePID)
-	graphql.GET("", gql.Get)
+	graphql.GET( "", gql.Get)
+	graphql.POST("", gql.Post)
 
 	results := app.Group("/result")
 	results.Use(auth.ResultAuth(&keyring))

--- a/api/cmd/query/main.go
+++ b/api/cmd/query/main.go
@@ -193,6 +193,7 @@ func main() {
 	basic := api.MakeBasicEndpoint(&keyring, opts.storageURL, cmdable, tokens)
 	slice := api.MakeSlice(&keyring, opts.storageURL, cmdable, tokens)
 	curtain := api.MakeCurtain(&keyring, opts.storageURL, cmdable, tokens)
+	gql := api.MakeGraphQL(&keyring, opts.storageURL, cmdable, tokens)
 	result := api.Result {
 		Timeout: time.Second * 15,
 		StorageURL: opts.storageURL,
@@ -222,6 +223,10 @@ func main() {
 	queries.GET("/:guid", basic.Entry)
 	queries.GET("/:guid/slice/:dimension/:lineno", slice.Get)
 	queries.GET("/:guid/curtain", curtain.Get)
+
+	graphql := app.Group("/graphql")
+	graphql.Use(util.GeneratePID)
+	graphql.GET("", gql.Get)
 
 	results := app.Group("/result")
 	results.Use(auth.ResultAuth(&keyring))

--- a/api/go.mod
+++ b/api/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-redis/redis/v8 v8.6.0
 	github.com/google/uuid v1.2.0
+	github.com/graph-gophers/graphql-go v1.1.0
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/stretchr/testify v1.7.0
 	github.com/vmihailenco/msgpack/v5 v5.2.3

--- a/api/go.sum
+++ b/api/go.sum
@@ -58,6 +58,8 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/graph-gophers/graphql-go v1.1.0 h1:wVVEPeC5IXelyaQ8UyWKugIyNIFOVF9Kn+gu/1/tXTE=
+github.com/graph-gophers/graphql-go v1.1.0/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -79,6 +81,8 @@ github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISq
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pborman/getopt/v2 v2.1.0 h1:eNfR+r+dWLdWmV8g5OlpyrTYHkhVNxHBdN2cCrJmOEA=
 github.com/pborman/getopt/v2 v2.1.0/go.mod h1:4NtW75ny4eBw9fO1bhtNdYTlZKYX5/tBLtsOpwKIKd0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,4 +1,5 @@
 azure-storage-blob
+gql
 hypothesis
 msal
 numpy

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -18,6 +18,7 @@ packages =
 
 install_requires =
     azure-storage-blob
+    gql
     msal
     numpy
     requests


### PR DESCRIPTION
This is a very exciting feature, introduced with a terrible
implementation.

Motivation
----------
So why this change? When playing around with various scenarios and
client implementations, it became quite clear that what oneseismic
really is deep down is a database engine. What you quickly want from
that is proper user driven queries, which you can build on top of the
REST URL-maps-to-resource scheme, but is quite cumbersome.

For ease of implementation, the approach was to have a very simple
interface for queries (since it has to be mapped to the concept of "the
resource"), and let clients handle mapping from whatever structure they
had into dimension/lineo, array-of-pairs etc. The more I work on this
the more I realise that you want some server support for easy-to-write
queries too.

What follows is that we want oneseismic to use a proper query language,
not some implicit language on a poorly documented schema of URLs. This
plays well with the recent developments where queries go through a
plan-and-optimise stage, before any data is actually being fetched.

All in all this introduces a new problem: building a query language.

Enter GraphQL
-------------
It's quite clear that oneseismic should not build its own query
language - it would have no support in popular languages, and building
and maintaining a good grammar and tooling is a massive task.
Fortunately, GraphQL seems a pretty good fit with a bunch of standard
tooling, and maps quite well onto the problem - it's a good third-party
solution for oneseismic.

The most important aspect is the introduction of a machine-readiable
schema. While REST APIs have stuff like OpenAPI, it was never really
introduced in oneseismic, and it is an "add-on". Of course there is
always a schema, but in oneseismic's case it was never formalised.

A quick demo
------------
This is the old (URL-based) workflow
```
GET oneseismic.equinor.com/query/0d235a7138104e00c421e63f5e3261bf2dc3254b/slice/0/152
response: {
    "authorization": "<key>"
    "location": "result/<pid>",
    "status": "result/<pid>/status"
}

```
And with this patch applied

```
GET oneseismic.equinor.com/graphql?{cube(id:"0d235a7138104e00c421e63f5e3261bf2dc3254b"){slice(kind:0,id:152){url, key}}}
response: {
    "data": {
        "cube": {
            "slice": {
                "url": "result/<pid>",
                "key": "<key>
            }
        }
    }
}
```

While both more verbose and deeply nested, it is parsed and expanded
using off-the-shelf libraries, and come with significant opportunities -
for example, all parameters are named and not url-position dependent,
and have support for enums:

```
query {
    cube(id: "0d235a7138104e00c421e63f5e3261bf2dc3254b") {
        slice(kind: inline, id:152) {
            url
            key
        }
    }
}
```

This is what the clients would then have to generate. This means clients
can also ask for a lot of other useful information, such as cube layout,
geometry, position in the same query as data is requested. On top of
that, GraphQL tools have support for exploring the schema, which means
good opportunities for evolving the data model. None of this is included
in this patch though, this only implements the model (and limitations)
in the /query based approach with GraphQL.

Implementation
--------------
The implementation is quite bad - it pretty much copies the
implementation of the /slice and /curtain endpoints into the GraphQL
handlers, and fixes compiler errors. This makes for a quick operational
/graphql endpoint without breaking the old /query endpoints, but an ugly
implementation with tons of warts. The graphql.go implementation should
be expected to be significantly rewritten with abstraction that fits the
new model.

From the looks of it, the C++ native tooling story for around graphql is
not stellar, but it seems alright in go. As a quick prototype go is a
good fit for this anyway, but at this point it is unclear if the Go <->
C++ communication protocol and data model should change, and at what
layer the proper business logic should live. Regardless, no change is
introduced with this patch, and the graphql resolvers simply produce the
same internal structures that the URL encoded schema did.

The way forward
---------------
I fully expect graphql to replace the REST model entirely, with a
notable exception: Response payloads are too slow, heavy, and
unpractical to be returned directly by the graphql, so the concept of a
oneseismic Promise type is introduced. This behaves like the promise
most (all?) programming languages, and is just the /result endpoint.
Clients will be aware of this, and use this information to fetch
(numerical) result of queries, although other query data may be returned
in the standard graphql manner.

The python libraries will have to be ported to call the graphql
endpoint, rather than the /query endpoint.

I expect the schema and input types to develop rapidly. I suspect that
the graphql implementations make high quality testing easier, because it
is a weak point in the test suite as of now.