### PR TITLE
Refactor scheduling message format; extend slice() query

### DIFF
--- a/api/api/endpoint.go
+++ b/api/api/endpoint.go
@@ -4,7 +4,6 @@ import (
 	"github.com/go-redis/redis/v8"
 
 	"github.com/equinor/oneseismic/api/internal/auth"
-	"github.com/equinor/oneseismic/api/internal/message"
 )
 
 type BasicEndpoint struct {
@@ -29,22 +28,5 @@ func MakeBasicEndpoint(
 		 * constructed directly by the caller.
 		 */
 		sched:   newScheduler(storage),
-	}
-}
-
-func (be *BasicEndpoint) MakeTask(
-	pid       string,
-	guid      string,
-	token     string,
-	manifest  interface{},
-	shape     []int32,
-) *message.Task {
-	return &message.Task {
-		Pid:             pid,
-		Token:           token,
-		Guid:            guid,
-		StorageEndpoint: be.endpoint,
-		Manifest:        manifest,
-		Shape:           shape,
 	}
 }

--- a/api/api/endpoint.go
+++ b/api/api/endpoint.go
@@ -36,7 +36,7 @@ func (be *BasicEndpoint) MakeTask(
 	pid       string,
 	guid      string,
 	token     string,
-	manifest  []byte,
+	manifest  interface{},
 	shape     []int32,
 	shapecube []int32,
 ) *message.Task {
@@ -45,7 +45,7 @@ func (be *BasicEndpoint) MakeTask(
 		Token:           token,
 		Guid:            guid,
 		StorageEndpoint: be.endpoint,
-		Manifest:        string(manifest),
+		Manifest:        manifest,
 		Shape:           shape,
 		ShapeCube:       shapecube,
 	}

--- a/api/api/endpoint.go
+++ b/api/api/endpoint.go
@@ -38,7 +38,6 @@ func (be *BasicEndpoint) MakeTask(
 	token     string,
 	manifest  interface{},
 	shape     []int32,
-	shapecube []int32,
 ) *message.Task {
 	return &message.Task {
 		Pid:             pid,
@@ -47,6 +46,5 @@ func (be *BasicEndpoint) MakeTask(
 		StorageEndpoint: be.endpoint,
 		Manifest:        manifest,
 		Shape:           shape,
-		ShapeCube:       shapecube,
 	}
 }

--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -72,7 +72,6 @@ func (s *resolver) MakeSliceTask(
 	token     string,
 	manifest  interface{},
 	shape     []int32,
-	shapecube []int32,
 	guid      string,
 	dim       int,
 	lineno    int,
@@ -83,7 +82,6 @@ func (s *resolver) MakeSliceTask(
 		token,
 		manifest,
 		shape,
-		shapecube,
 	)
 	task.Function = "slice"
 	task.Params   = &message.SliceParams {
@@ -99,7 +97,6 @@ func (c *resolver) MakeCurtainTask(
 	token     string,
 	manifest  interface{},
 	shape     []int32,
-	shapecube []int32,
 	params    *message.CurtainParams,
 ) *message.Task {
 	task := c.BasicEndpoint.MakeTask(
@@ -108,7 +105,6 @@ func (c *resolver) MakeCurtainTask(
 		token,
 		manifest,
 		shape,
-		shapecube,
 	)
 	task.Function = "curtain"
 	task.Params   = params
@@ -267,18 +263,11 @@ func (c *cube) Slice(
 		return nil, err
 	}
 
-	dimensions := c.manifest["dimensions"].([]interface{})
-	cubeshape := make([]int32, 0, len(dimensions))
-	for i := 0; i < len(dimensions); i++ {
-		dim := dimensions[i].([]interface {})
-		cubeshape = append(cubeshape, int32(len(dim)))
-	}
 	msg := c.root.MakeSliceTask(
 		pid,
 		token,
 		c.manifest,
 		[]int32{ 64, 64, 64 },
-		cubeshape,
 		string(c.id),
 		int(args.Kind),
 		int(args.Id),
@@ -343,19 +332,12 @@ func (c *cube) Curtain(
 		return nil, err
 	}
 
-	dimensions := c.manifest["dimensions"].([]interface{})
-	cubeshape := make([]int32, 0, len(dimensions))
-	for i := 0; i < len(dimensions); i++ {
-		dim := dimensions[i].([]interface {})
-		cubeshape = append(cubeshape, int32(len(dim)))
-	}
 	msg := c.root.MakeCurtainTask(
 		pid,
 		string(c.id),
 		token,
 		c.manifest,
 		[]int32{ 64, 64, 64 },
-		cubeshape,
 		toCurtainParams(args.Coords),
 	)
 

--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -44,7 +44,7 @@ func (r *resolver) Cubes(ctx context.Context) ([]graphql.ID, error) {
 	endpoint, err := url.Parse(r.endpoint)
 	if err != nil {
 		log.Printf("pid=%s %v", pid, err)
-		return []graphql.ID{}, err
+		return nil, err
 	}
 
 	cubes, err := util.WithOnbehalfAndRetry(
@@ -56,7 +56,7 @@ func (r *resolver) Cubes(ctx context.Context) ([]graphql.ID, error) {
 	)
 	if err != nil {
 		log.Printf("pid=%s, %v", pid, err)
-		return []graphql.ID{}, err
+		return nil, err
 	}
 
 	guids := cubes.([]string)
@@ -219,7 +219,7 @@ func (c *cube) Slice(
 		return nil, err
 	}
 
-	msg := message.Task {
+	msg := message.Query {
 		Pid:             pid,
 		Token:           token,
 		Guid:            string(c.id),
@@ -227,7 +227,7 @@ func (c *cube) Slice(
 		StorageEndpoint: c.root.endpoint,
 		Shape:           []int32{ 64, 64, 64 },
 		Function:        "slice",
-		Params:          args,
+		Args:            args,
 	}
 	query, err := c.root.sched.MakeQuery(&msg)
 	if err != nil {
@@ -277,7 +277,7 @@ func (c *cube) Curtain(
 		return nil, err
 	}
 
-	msg := message.Task {
+	msg := message.Query {
 		Pid:             pid,
 		Token:           token,
 		Guid:            string(c.id),
@@ -285,7 +285,7 @@ func (c *cube) Curtain(
 		StorageEndpoint: c.root.endpoint,
 		Shape:           []int32{ 64, 64, 64 },
 		Function:        "curtain",
-		Params:          args,
+		Args:            args,
 	}
 	query, err := c.root.sched.MakeQuery(&msg)
 	if err != nil {

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -12,11 +12,11 @@ type Message interface {
 }
 
 /*
- * Corresponds to common_task and derivatives in oneseismic/messages.hpp. This
+ * Corresponds to basic_query and derivatives in oneseismic/messages.hpp. This
  * is the process prototype that groups request parameters, request metadata,
  * authorization etc. into a single message.
  */
-type Task struct {
+type Query struct {
 	Pid             string       `json:"pid"`
 	Token           string       `json:"token"`
 	Guid            string       `json:"guid"`
@@ -24,7 +24,30 @@ type Task struct {
 	StorageEndpoint string       `json:"storage_endpoint"`
 	Shape           []int32      `json:"shape"`
 	Function        string       `json:"function"`
-	Params          interface {} `json:"params"`
+	Args            interface {} `json:"args"`
+}
+
+func (msg *Query) Pack() ([]byte, error) {
+	return json.Marshal(msg)
+}
+
+func (msg *Query) Unpack(doc []byte) (*Query, error) {
+	return msg, json.Unmarshal(doc, msg)
+}
+
+/*
+ * Corresponds to basic_task and derivatives in oneseismic/messages.hpp, and
+ * is read from the worker nodes when performing a task, which combined makes
+ * up a process.
+ */
+type Task struct {
+	Pid             string       `json:"pid"`
+	Token           string       `json:"token"`
+	Guid            string       `json:"guid"`
+	StorageEndpoint string       `json:"storage_endpoint"`
+	Shape           []int32      `json:"shape"`
+	ShapeCube       []int32      `json:"shape-cube"`
+	Function        string       `json:"function"`
 }
 
 func (msg *Task) Pack() ([]byte, error) {

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -23,7 +23,6 @@ type Task struct {
 	Manifest        interface {} `json:"manifest"`
 	StorageEndpoint string       `json:"storage_endpoint"`
 	Shape           []int32      `json:"shape"`
-	ShapeCube       []int32      `json:"shape-cube"`
 	Function        string       `json:"function"`
 	Params          interface {} `json:"params"`
 }

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -20,7 +20,7 @@ type Task struct {
 	Pid             string       `json:"pid"`
 	Token           string       `json:"token"`
 	Guid            string       `json:"guid"`
-	Manifest        string       `json:"manifest"`
+	Manifest        interface {} `json:"manifest"`
 	StorageEndpoint string       `json:"storage_endpoint"`
 	Shape           []int32      `json:"shape"`
 	ShapeCube       []int32      `json:"shape-cube"`

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -95,7 +95,7 @@ struct process_header : Packable< process_header > {
 
 struct slice_query : public basic_query, Packable< slice_query > {
     int dim;
-    int lineno;
+    int idx;
 };
 
 struct curtain_query : public basic_query, Packable< curtain_query > {

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -40,7 +40,6 @@ struct basic_query {
     manifestdoc        manifest;
     std::string        storage_endpoint;
     std::vector< int > shape;
-    std::vector< int > shape_cube;
     std::string        function;
 };
 
@@ -52,9 +51,12 @@ struct basic_task {
         guid             (q.guid),
         storage_endpoint (q.storage_endpoint),
         shape            (q.shape),
-        shape_cube       (q.shape_cube),
         function         (q.function)
-    {}
+    {
+        this->shape_cube.reserve(q.manifest.dimensions.size());
+        for (const auto& d : q.manifest.dimensions)
+            this->shape_cube.push_back(d.size());
+    }
 
     std::string        pid;
     std::string        token;

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -27,6 +27,10 @@ class bad_value : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
+struct not_found : public std::out_of_range {
+    using std::out_of_range::out_of_range;
+};
+
 struct manifestdoc {
     std::vector< std::vector< int > > dimensions;
 };

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -23,6 +23,10 @@ class bad_message : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
+class bad_value : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
 struct manifestdoc {
     std::vector< std::vector< int > > dimensions;
 };

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -113,7 +113,7 @@ struct slice_task : public basic_task, Packable< slice_task > {
     {}
 
     int dim;
-    int lineno;
+    int idx;
     std::vector< std::vector< int > > ids;
 };
 

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -23,6 +23,10 @@ class bad_message : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
+struct manifestdoc {
+    std::vector< std::vector< int > > dimensions;
+};
+
 /*
  * The *query messages are parsing utilities for the input messages built from
  * the graphql queries. They help build a corresponding *task which is fed to
@@ -33,7 +37,7 @@ struct basic_query {
     std::string        pid;
     std::string        token;
     std::string        guid;
-    std::string        manifest;
+    manifestdoc        manifest;
     std::string        storage_endpoint;
     std::vector< int > shape;
     std::vector< int > shape_cube;

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -7,6 +7,18 @@
 
 namespace one {
 
+template < typename T >
+struct Packable {
+    std::string pack() const noexcept (false);
+    void unpack(const char* fst, const char* lst) noexcept (false);
+};
+
+template < typename T >
+struct MsgPackable {
+    std::string pack() const noexcept (false);
+    void unpack(const char* fst, const char* lst) noexcept (false);
+};
+
 class bad_message : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
@@ -26,9 +38,6 @@ struct basic_query {
     std::vector< int > shape;
     std::vector< int > shape_cube;
     std::string        function;
-
-    std::string pack() const noexcept(false);
-    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
 struct basic_task {
@@ -50,9 +59,6 @@ struct basic_task {
     std::vector< int > shape;
     std::vector< int > shape_cube;
     std::string        function;
-
-    std::string pack() const noexcept(false);
-    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
 /*
@@ -66,35 +72,26 @@ struct basic_task {
  * The contents and order of the shape and index depend on the request type and
  * parameters.
  */
-struct process_header {
+struct process_header : Packable< process_header > {
     std::string        pid;
     int                ntasks;
     std::vector< int > shape;
     std::vector< std::vector< int > > index;
-
-    std::string pack() const noexcept(false);
-    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
-struct slice_query : public basic_query {
+struct slice_query : public basic_query, Packable< slice_query > {
     int dim;
     int lineno;
-
-    std::string pack() const noexcept(false);
-    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
-struct curtain_query : public basic_query {
+struct curtain_query : public basic_query, Packable< curtain_query > {
     std::vector< int > dim0s;
     std::vector< int > dim1s;
-
-    std::string pack() const noexcept(false);
-    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
 /*
  */
-struct slice_task : public basic_task {
+struct slice_task : public basic_task, Packable< slice_task > {
     slice_task() = default;
     explicit slice_task(const slice_query& q) :
         basic_task(q),
@@ -104,9 +101,6 @@ struct slice_task : public basic_task {
     int dim;
     int lineno;
     std::vector< std::vector< int > > ids;
-
-    std::string pack() const noexcept (false);
-    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
 struct tile {
@@ -118,15 +112,12 @@ struct tile {
     std::vector< float > v;
 };
 
-struct slice_tiles {
+struct slice_tiles : public MsgPackable< slice_tiles > {
     /*
      * The shape of the slice itself
      */
     std::vector< int > shape;
     std::vector< tile > tiles;
-
-    std::string pack() const noexcept(false);
-    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
 struct single {
@@ -139,13 +130,9 @@ struct single {
     std::vector< std::array< int, 2 > > coordinates;
 };
 
-struct curtain_task : public basic_task {
+struct curtain_task : public basic_task, Packable< curtain_task > {
     using basic_task::basic_task;
-
     std::vector< single > ids;
-
-    std::string pack() const noexcept(false);
-    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
 struct trace {
@@ -153,11 +140,8 @@ struct trace {
     std::vector< float > v;
 };
 
-struct curtain_traces {
+struct curtain_traces : public MsgPackable< curtain_traces > {
     std::vector< trace > traces;
-
-    std::string pack() const noexcept(false);
-    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
 }

--- a/core/include/oneseismic/plan.hpp
+++ b/core/include/oneseismic/plan.hpp
@@ -5,11 +5,9 @@
 #include <string>
 #include <vector>
 
-namespace one {
+#include <oneseismic/messages.hpp>
 
-struct not_found : public std::out_of_range {
-    using std::out_of_range::out_of_range;
-};
+namespace one {
 
 std::vector< std::string >
 mkschedule(const char* doc, int len, int task_size) noexcept (false);

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -185,16 +185,16 @@ void from_json(const nlohmann::json& doc, curtain_query& query) noexcept (false)
 
 void to_json(nlohmann::json& doc, const slice_task& task) noexcept (false) {
     to_json(doc, static_cast< const basic_task& >(task));
-    doc["dim"]    = task.dim;
-    doc["lineno"] = task.lineno;
-    doc["ids"]    = task.ids;
+    doc["dim"] = task.dim;
+    doc["idx"] = task.idx;
+    doc["ids"] = task.ids;
 }
 
 void from_json(const nlohmann::json& doc, slice_task& task) noexcept (false) {
     from_json(doc, static_cast< basic_task& >(task));
-    doc.at("dim")   .get_to(task.dim);
-    doc.at("lineno").get_to(task.lineno);
-    doc.at("ids")   .get_to(task.ids);
+    doc.at("dim").get_to(task.dim);
+    doc.at("idx").get_to(task.idx);
+    doc.at("ids").get_to(task.ids);
 
     if (task.ids.empty()) {
         /*

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -66,14 +66,12 @@ void from_json(const nlohmann::json& doc, manifestdoc& m) noexcept (false) {
 }
 
 void to_json(nlohmann::json& doc, const basic_query& query) noexcept (false) {
-    assert(query.shape_cube.size() == query.shape.size());
     doc["pid"]              = query.pid;
     doc["token"]            = query.token;
     doc["guid"]             = query.guid;
     doc["manifest"]         = query.manifest;
     doc["storage_endpoint"] = query.storage_endpoint;
     doc["shape"]            = query.shape;
-    doc["shape-cube"]       = query.shape_cube;
     doc["function"]         = query.function;
 }
 
@@ -84,12 +82,10 @@ void from_json(const nlohmann::json& doc, basic_query& query) noexcept (false) {
     doc.at("manifest")        .get_to(query.manifest);
     doc.at("storage_endpoint").get_to(query.storage_endpoint);
     doc.at("shape")           .get_to(query.shape);
-    doc.at("shape-cube")      .get_to(query.shape_cube);
     doc.at("function")        .get_to(query.function);
 }
 
 void to_json(nlohmann::json& doc, const basic_task& task) noexcept (false) {
-    assert(task.shape_cube.size() == task.shape.size());
     doc["pid"]              = task.pid;
     doc["token"]            = task.token;
     doc["guid"]             = task.guid;
@@ -97,6 +93,7 @@ void to_json(nlohmann::json& doc, const basic_task& task) noexcept (false) {
     doc["shape"]            = task.shape;
     doc["shape-cube"]       = task.shape_cube;
     doc["function"]         = task.function;
+    assert(task.shape_cube.size() == task.shape.size());
 }
 
 void from_json(const nlohmann::json& doc, basic_task& task) noexcept (false) {

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -141,14 +141,6 @@ void from_json(const nlohmann::json& doc, slice_query& query) noexcept (false) {
     params.at("lineno").get_to(query.lineno);
 }
 
-void to_json(nlohmann::json& doc, const curtain_query& query) noexcept (false) {
-    to_json(doc, static_cast< const basic_query& >(query));
-    doc["function"] = "curtain";
-    auto& params = doc["params"];
-    params["dim0s"] = query.dim0s;
-    params["dim1s"] = query.dim1s;
-}
-
 void from_json(const nlohmann::json& doc, curtain_query& query) noexcept (false) {
     from_json(doc, static_cast< basic_query& >(query));
 
@@ -158,8 +150,20 @@ void from_json(const nlohmann::json& doc, curtain_query& query) noexcept (false)
     }
 
     const auto& params = doc.at("params");
-    params.at("dim0s").get_to(query.dim0s);
-    params.at("dim1s").get_to(query.dim1s);
+
+    std::vector< std::vector< int > > coords;
+    params.at("coords").get_to(coords);
+    query.dim0s.reserve(coords.size());
+    query.dim1s.reserve(coords.size());
+
+    try {
+        for (const auto& pair : coords) {
+            query.dim0s.push_back(pair.at(0));
+            query.dim1s.push_back(pair.at(1));
+        }
+    } catch (std::out_of_range&) {
+        throw bad_value("bad coord arg; expected list-of-pairs");
+    }
 }
 
 void to_json(nlohmann::json& doc, const slice_task& task) noexcept (false) {

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -57,6 +57,14 @@ template class Packable< curtain_task >;
 template class MsgPackable< slice_tiles >;
 template class MsgPackable< curtain_traces >;
 
+void to_json(nlohmann::json& doc, const manifestdoc& m) noexcept (false) {
+    doc["dimensions"] = m.dimensions;
+}
+
+void from_json(const nlohmann::json& doc, manifestdoc& m) noexcept (false) {
+    doc.at("dimensions").get_to(m.dimensions);
+}
+
 void to_json(nlohmann::json& doc, const basic_query& query) noexcept (false) {
     assert(query.shape_cube.size() == query.shape.size());
     doc["pid"]              = query.pid;

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -123,9 +123,9 @@ void from_json(const nlohmann::json& doc, process_header& head) noexcept (false)
 void to_json(nlohmann::json& doc, const slice_query& query) noexcept (false) {
     to_json(doc, static_cast< const basic_query& >(query));
     doc["function"] = "slice";
-    auto& params = doc["params"];
-    params["dim"]    = query.dim;
-    params["lineno"] = query.lineno;
+    auto& args = doc["args"];
+    args["dim"]    = query.dim;
+    args["lineno"] = query.lineno;
 }
 
 void from_json(const nlohmann::json& doc, slice_query& query) noexcept (false) {
@@ -136,9 +136,9 @@ void from_json(const nlohmann::json& doc, slice_query& query) noexcept (false) {
         throw bad_message(fmt::format(msg, query.function));
     }
 
-    const auto& params = doc.at("params");
-    params.at("dim")   .get_to(query.dim);
-    params.at("lineno").get_to(query.lineno);
+    const auto& args = doc.at("args");
+    args.at("dim")   .get_to(query.dim);
+    args.at("lineno").get_to(query.lineno);
 }
 
 void from_json(const nlohmann::json& doc, curtain_query& query) noexcept (false) {
@@ -149,10 +149,10 @@ void from_json(const nlohmann::json& doc, curtain_query& query) noexcept (false)
         throw bad_message(fmt::format(msg, query.function));
     }
 
-    const auto& params = doc.at("params");
+    const auto& args = doc.at("args");
 
     std::vector< std::vector< int > > coords;
-    params.at("coords").get_to(coords);
+    args.at("coords").get_to(coords);
     query.dim0s.reserve(coords.size());
     query.dim1s.reserve(coords.size());
 

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -308,7 +308,6 @@ schedule_maker< one::curtain_query, one::curtain_task >::build(
 
     auto gvt = geometry(query);
     const auto zfrags  = gvt.fragment_count(gvt.mkdim(2));
-    const auto zheight = gvt.fragment_shape()[2];
 
     /*
      * Guess the number of coordinates per fragment. A reasonable assumption is

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -207,10 +207,6 @@ schedule_maker< one::slice_query, one::slice_task >::build(
     const auto pin = std::distance(index.begin(), itr);
     auto gvt = geometry(query);
 
-    // TODO: name loop
-    for (const auto& dimension : dimensions)
-        task.shape_cube.push_back(dimension.size());
-
     const auto to_vec = [](const auto& x) {
         return std::vector< int > { int(x[0]), int(x[1]), int(x[2]) };
     };

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -188,7 +188,7 @@ schedule_maker< one::slice_query, one::slice_task >::build(
         return std::vector< int > { int(x[0]), int(x[1]), int(x[2]) };
     };
 
-    task.lineno = query.idx % gvt.fragment_shape()[query.dim];
+    task.idx = query.idx % gvt.fragment_shape()[query.dim];
     const auto ids = gvt.slice(gvt.mkdim(query.dim), query.idx);
     // TODO: name loop
     for (const auto& id : ids)

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -195,11 +195,6 @@ schedule_maker< one::slice_query, one::slice_task >::build(
         }
     }(query);
 
-    /*
-     * TODO:
-     * faster to not make vector, but rather parse-and-compare individual
-     * integers?
-     */
     const auto itr = std::find(index.begin(), index.end(), query.lineno);
     if (itr == index.end()) {
         const auto msg = "line (= {}) not found in index";

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -13,16 +13,17 @@
 
 namespace {
 
-one::gvt< 3 > geometry(
-        const one::manifestdoc& manifest,
-        const nlohmann::json& shape) noexcept (false) {
+one::gvt< 3 > geometry(const one::basic_query& query) noexcept (false) {
+    const auto& dimensions = query.manifest.dimensions;
+    const auto& shape = query.shape;
+
     return one::gvt< 3 > {
-        { manifest.dimensions[0].size(),
-          manifest.dimensions[1].size(),
-          manifest.dimensions[2].size(), },
-        { shape[0].get< std::size_t >(),
-          shape[1].get< std::size_t >(),
-          shape[2].get< std::size_t >(), }
+        { dimensions[0].size(),
+          dimensions[1].size(),
+          dimensions[2].size(), },
+        { std::size_t(shape[0]),
+          std::size_t(shape[1]),
+          std::size_t(shape[2]), }
     };
 }
 
@@ -204,7 +205,7 @@ schedule_maker< one::slice_query, one::slice_task >::build(
     }
 
     const auto pin = std::distance(index.begin(), itr);
-    auto gvt = geometry(query.manifest, query.shape);
+    auto gvt = geometry(query);
 
     // TODO: name loop
     for (const auto& dimension : dimensions)
@@ -230,7 +231,7 @@ schedule_maker< one::slice_query, one::slice_task >::header(
     int ntasks
 ) noexcept (false) {
     const auto& mdims = query.manifest.dimensions;
-    const auto gvt  = geometry(query.manifest, query.shape);
+    const auto gvt  = geometry(query);
     const auto dim  = gvt.mkdim(query.dim);
     const auto gvt2 = gvt.squeeze(dim);
     const auto fs2  = gvt2.fragment_shape();
@@ -309,7 +310,7 @@ schedule_maker< one::curtain_query, one::curtain_task >::build(
     to_cartesian_inplace(query.manifest.dimensions[1], dim1s);
     auto& ids = task.ids;
 
-    auto gvt = geometry(query.manifest, query.shape);
+    auto gvt = geometry(query);
     const auto zfrags  = gvt.fragment_count(gvt.mkdim(2));
     const auto zheight = gvt.fragment_shape()[2];
 
@@ -390,7 +391,7 @@ schedule_maker< one::curtain_query, one::curtain_task >::header(
     head.pid    = query.pid;
     head.ntasks = ntasks;
 
-    const auto gvt  = geometry(query.manifest, query.shape);
+    const auto gvt  = geometry(query);
     const auto zpad = gvt.nsamples_padded(gvt.mkdim(gvt.ndims - 1));
     head.shape = {
         int(query.dim0s.size()),

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -182,22 +182,24 @@ schedule_maker< one::slice_query, one::slice_task >::build(
 {
     auto task = one::slice_task(query);
 
-    const auto& dimensions = query.manifest.dimensions;
-    if (!(0 <= query.dim && query.dim < dimensions.size())) {
-        const auto msg = fmt::format(
-            "param.dimension (= {}) not in [0, {})",
-            query.dim,
-            dimensions.size()
-        );
-        throw one::not_found(msg);
-    }
+    const auto& index = [](const auto& query) {
+        try {
+            return query.manifest.dimensions.at(query.dim);
+        } catch (std::out_of_range&) {
+            const auto msg = fmt::format(
+                "args.dim (= {}) not in [0, {})",
+                query.dim,
+                query.manifest.dimensions.size()
+            );
+            throw one::not_found(msg);
+        }
+    }(query);
 
     /*
      * TODO:
      * faster to not make vector, but rather parse-and-compare individual
      * integers?
      */
-    const auto& index = dimensions[query.dim];
     const auto itr = std::find(index.begin(), index.end(), query.lineno);
     if (itr == index.end()) {
         const auto msg = "line (= {}) not found in index";

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -113,7 +113,7 @@ void slice::init(const char* msg, int len) {
 
     this->set_fragment_shape(fmt::format("{}", fmt::join(fragment_shape, "-")));
     this->dim = g3.mkdim(this->input.dim);
-    this->idx = this->input.lineno;
+    this->idx = this->input.idx;
     this->layout = fragment_shape.slice_stride(this->dim);
     this->gvt = one::gvt< 2 >(
         cube_shape.squeeze(this->dim),

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -21,7 +21,7 @@ one::FID< 3 > id3(const Seq& seq) noexcept (false) {
     };
 }
 
-one::gvt< 3 > gvt3(const one::common_task& task) {
+one::gvt< 3 > gvt3(const one::basic_task& task) {
     assert(task.shape[0] > 0);
     assert(task.shape[1] > 0);
     assert(task.shape[2] > 0);
@@ -48,7 +48,7 @@ public:
     std::string pack() override;
 
 private:
-    one::slice_fetch input;
+    one::slice_task  input;
     one::slice_tiles output;
 
     one::dimension< 3 > dim = one::dimension< 3 >(0);
@@ -64,7 +64,7 @@ public:
     std::string pack() override;
 
 private:
-    one::curtain_fetch  input;
+    one::curtain_task   input;
     one::curtain_traces output;
     one::gvt< 3 >       gvt;
     std::vector< int >  traceindex;

--- a/core/tests/messages.cpp
+++ b/core/tests/messages.cpp
@@ -22,9 +22,9 @@ bool operator == (const one::basic_task& lhs, const one::basic_task& rhs) {
 
 bool operator == (const one::slice_task& lhs, const one::slice_task& rhs) {
     return static_cast< const one::basic_task& >(lhs) == rhs
-        && lhs.dim    == rhs.dim
-        && lhs.lineno == rhs.lineno
-        && lhs.ids    == rhs.ids
+        && lhs.dim == rhs.dim
+        && lhs.idx == rhs.idx
+        && lhs.ids == rhs.ids
     ;
 }
 
@@ -59,7 +59,7 @@ TEST_CASE("well-formed slice-query is unpacked correctly") {
     CHECK(query.storage_endpoint == "https://storage.com");
     CHECK_THAT(query.shape,      Equals(std::vector< int >{ 64,  64,  64}));
     CHECK(query.dim == 0);
-    CHECK(query.lineno == 0);
+    CHECK(query.idx == 0);
 }
 
 TEST_CASE("unpacking query with missing field fails") {
@@ -117,7 +117,7 @@ TEST_CASE("slice-task can round trip packing") {
     task.shape_cube = { 512, 512, 512 };
     task.function = "slice";
     task.dim = 1;
-    task.lineno = 2;
+    task.idx = 2;
     task.ids = {
         { 0, 1, 2 },
         { 3, 4, 5 },

--- a/core/tests/messages.cpp
+++ b/core/tests/messages.cpp
@@ -95,7 +95,7 @@ TEST_CASE("unpacking query with missing field fails") {
             const auto doc = fmt::format("{{\n{}\n}}", fmt::join(parts, ",\n"));
             const auto fst = doc.data();
             const auto lst = doc.data() + doc.size();
-            one::basic_query query;
+            one::slice_query query;
             CHECK_THROWS(query.unpack(fst, lst));
         }
 

--- a/core/tests/messages.cpp
+++ b/core/tests/messages.cpp
@@ -59,7 +59,7 @@ TEST_CASE("well-formed slice-query is unpacked correctly") {
         "manifest": { "dimensions": [] },
         "shape": [64, 64, 64],
         "function": "slice",
-        "params": {
+        "args": {
             "dim": 0,
             "lineno": 10
         }
@@ -112,7 +112,7 @@ TEST_CASE("unpacking message with wrong function tag fails") {
         "storage_endpoint": "https://storage.com",
         "shape": [64, 64, 64],
         "function": "broken",
-        "params": {
+        "args": {
             "dim": 0,
             "lineno": 10
         }

--- a/core/tests/messages.cpp
+++ b/core/tests/messages.cpp
@@ -32,7 +32,6 @@ bool operator == (const one::basic_task& lhs, const one::basic_task& rhs) {
         && lhs.guid             == rhs.guid
         && lhs.storage_endpoint == rhs.storage_endpoint
         && lhs.shape            == rhs.shape
-        && lhs.shape_cube       == rhs.shape_cube
         && lhs.function         == rhs.function
     ;
 }
@@ -59,7 +58,6 @@ TEST_CASE("well-formed slice-query is unpacked correctly") {
         "storage_endpoint": "https://storage.com",
         "manifest": { "dimensions": [] },
         "shape": [64, 64, 64],
-        "shape-cube": [128, 128, 128],
         "function": "slice",
         "params": {
             "dim": 0,
@@ -75,7 +73,6 @@ TEST_CASE("well-formed slice-query is unpacked correctly") {
     CHECK(query.manifest == one::manifestdoc {});
     CHECK(query.storage_endpoint == "https://storage.com");
     CHECK_THAT(query.shape,      Equals(std::vector< int >{ 64,  64,  64}));
-    CHECK_THAT(query.shape_cube, Equals(std::vector< int >{128, 128, 128}));
     CHECK(query.dim == 0);
     CHECK(query.lineno == 10);
 }
@@ -133,7 +130,6 @@ TEST_CASE("slice-query can round trip packing") {
     query.manifest = one::manifestdoc {};
     query.storage_endpoint = "https://storage.com";
     query.shape = { 64, 64, 64 };
-    query.shape_cube = { 128, 128, 128 };
     query.function = "slice";
     query.dim = 1;
     query.lineno = 2;
@@ -153,7 +149,6 @@ TEST_CASE("slice-query sets function to 'slice'") {
     query.manifest = one::manifestdoc {};
     query.storage_endpoint = "https://storage.com";
     query.shape = { 64, 64, 64 };
-    query.shape_cube = { 128, 128, 128 };
     query.function = "garbage";
     query.dim = 1;
     query.lineno = 2;
@@ -171,7 +166,7 @@ TEST_CASE("slice-task can round trip packing") {
     task.guid = "guid";
     task.storage_endpoint = "https://storage.com";
     task.shape = { 64, 64, 64 };
-    task.shape_cube = { 128, 128, 128 };
+    task.shape_cube = { 512, 512, 512 };
     task.function = "slice";
     task.dim = 1;
     task.lineno = 2;

--- a/core/tests/messages.cpp
+++ b/core/tests/messages.cpp
@@ -45,6 +45,10 @@ bool operator == (const one::slice_task& lhs, const one::slice_task& rhs) {
     ;
 }
 
+bool operator == (const one::manifestdoc& lhs, const one::manifestdoc& rhs) {
+    return lhs.dimensions == rhs.dimensions;
+}
+
 }
 
 TEST_CASE("well-formed slice-query is unpacked correctly") {
@@ -53,7 +57,7 @@ TEST_CASE("well-formed slice-query is unpacked correctly") {
         "token": "on-behalf-of-token",
         "guid": "object-id",
         "storage_endpoint": "https://storage.com",
-        "manifest": "{}",
+        "manifest": { "dimensions": [] },
         "shape": [64, 64, 64],
         "shape-cube": [128, 128, 128],
         "function": "slice",
@@ -68,7 +72,7 @@ TEST_CASE("well-formed slice-query is unpacked correctly") {
     CHECK(query.pid   == "some-pid");
     CHECK(query.token == "on-behalf-of-token");
     CHECK(query.guid  == "object-id");
-    CHECK(query.manifest == "{}");
+    CHECK(query.manifest == one::manifestdoc {});
     CHECK(query.storage_endpoint == "https://storage.com");
     CHECK_THAT(query.shape,      Equals(std::vector< int >{ 64,  64,  64}));
     CHECK_THAT(query.shape_cube, Equals(std::vector< int >{128, 128, 128}));
@@ -81,7 +85,7 @@ TEST_CASE("unpacking query with missing field fails") {
         R"("pid": "some-pid")",
         R"("token": "on-behalf-of-token")",
         R"("guid": "object-id")",
-        R"("manifest": "{}")",
+        R"("manifest": { "dimensions": [] })",
         R"("storage_endpoint": "http://storage.com")",
         R"("shape": [64, 64, 64])",
         R"("function": "slice")",
@@ -107,7 +111,7 @@ TEST_CASE("unpacking message with wrong function tag fails") {
         "pid": "some-pid",
         "token": "on-behalf-of-token",
         "guid": "object-id",
-        "manifest": "{}",
+        "manifest": { "dimensions": [] },
         "storage_endpoint": "https://storage.com",
         "shape": [64, 64, 64],
         "function": "broken",
@@ -126,7 +130,7 @@ TEST_CASE("slice-query can round trip packing") {
     query.pid = "pid";
     query.token = "token";
     query.guid = "guid";
-    query.manifest = "{}";
+    query.manifest = one::manifestdoc {};
     query.storage_endpoint = "https://storage.com";
     query.shape = { 64, 64, 64 };
     query.shape_cube = { 128, 128, 128 };
@@ -146,7 +150,7 @@ TEST_CASE("slice-query sets function to 'slice'") {
     query.pid = "pid";
     query.token = "token";
     query.guid = "guid";
-    query.manifest = "{}";
+    query.manifest = one::manifestdoc {};
     query.storage_endpoint = "https://storage.com";
     query.shape = { 64, 64, 64 };
     query.shape_cube = { 128, 128, 128 };

--- a/core/tests/process.cpp
+++ b/core/tests/process.cpp
@@ -16,8 +16,8 @@ one::slice_task default_slice_task() {
     input.shape      = { 64, 64, 64 };
     input.shape_cube = { 720, 860, 251 };
 
-    input.dim    = 0;
-    input.lineno = 0;
+    input.dim = 0;
+    input.idx = 0;
     return input;
 }
 
@@ -84,8 +84,8 @@ T unpack(const std::string& s) {
  */
 TEST_CASE("Slices extracted from chunks matches hand-extracted slice") {
     auto input = default_slice_task();
-    input.dim    = 1;
-    input.lineno = 1;
+    input.dim = 1;
+    input.idx = 1;
     input.ids = {
         { 0, 0, 0 },
         { 0, 0, 1 },

--- a/core/tests/process.cpp
+++ b/core/tests/process.cpp
@@ -6,8 +6,8 @@
 
 using namespace Catch::Matchers;
 
-one::slice_fetch default_slice_fetch() {
-    one::slice_fetch input;
+one::slice_task default_slice_task() {
+    one::slice_task input;
     input.pid   = "some-pid";
     input.token = "some-token";
     input.guid  = "some-guid";
@@ -22,7 +22,7 @@ one::slice_fetch default_slice_fetch() {
 }
 
 TEST_CASE("slice.fragments generates the right IDs from a task") {
-    auto input = default_slice_fetch();
+    auto input = default_slice_task();
     auto slice = one::proc::make("slice");
 
     SECTION("None when ids are empty") {
@@ -83,7 +83,7 @@ T unpack(const std::string& s) {
  * shape combinations etc.
  */
 TEST_CASE("Slices extracted from chunks matches hand-extracted slice") {
-    auto input = default_slice_fetch();
+    auto input = default_slice_task();
     input.dim    = 1;
     input.lineno = 1;
     input.ids = {
@@ -121,7 +121,7 @@ TEST_CASE("Slices extracted from chunks matches hand-extracted slice") {
 }
 
 TEST_CASE("slice.add is not sensitive to order") {
-    auto input = default_slice_fetch();
+    auto input = default_slice_task();
     input.ids = {
         { 0, 0, 0 },
         { 0, 0, 1 },
@@ -154,8 +154,8 @@ TEST_CASE("slice.add is not sensitive to order") {
     CHECK_THAT(unpacked.tiles.at(1).v, Equals(expected[1]));
 }
 
-one::curtain_fetch default_curtain_fetch() {
-    one::curtain_fetch input;
+one::curtain_task default_curtain_task() {
+    one::curtain_task input;
     input.pid   = "some-pid";
     input.token = "some-token";
     input.guid  = "some-guid";
@@ -168,7 +168,7 @@ one::curtain_fetch default_curtain_fetch() {
 }
 
 TEST_CASE("curtain.fragments generates the right IDs from a task") {
-    auto input = default_curtain_fetch();
+    auto input = default_curtain_task();
     auto slice = one::proc::make("curtain");
 
     SECTION("None when ids are empty") {
@@ -244,7 +244,7 @@ TEST_CASE("Curtains extracted from chunks matches hand-extracted curtain") {
      * by observing add(). The interface might need some tuning to make it
      * easier to test it without so much ceremony.
      */
-    auto input = default_curtain_fetch();
+    auto input = default_curtain_task();
     input.ids = {
         one::single { {0, 0, 0}, { {2, 1}, {2, 2} } },
         one::single { {0, 0, 1}, { {2, 1}, {2, 2} } },

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -223,7 +223,7 @@ class cube:
         query = f'''
         query {{
             cube(id: "{self.guid}") {{
-                slice(kind: {dim}, id: {lineno}) {{
+                sliceByLineno(dim: {dim}, lineno: {lineno}) {{
                     url
                     key
                 }}


### PR DESCRIPTION
The gist of this PR is that it moves input validation and transformation into C++, and cleans up some long-standing problems with the message format in exchange between the I/O and query system (in go) and the scheduler (in C++).

Almost-literally translated _queries_ are validated and assembled into _tasks_ in C++, which is now represented through distinct types. This brought along some nice simplification and fixed addressed some hygiene issues.

The patch set is built iteratively, but the understanding comes from messages.go and messages.hpp.

The slice() query is extended to sliceByLineno and sliceByIndex which interpret the parameters as line number and index respectively, giving the user the choice of reference system.