### PR TITLE
Always get directory in localfs_from_args

### DIFF
--- a/python/oneseismic/internal/argparse.py
+++ b/python/oneseismic/internal/argparse.py
@@ -136,7 +136,17 @@ def localfs_from_args(path):
     if path is None:
         path = Path()
     path = Path(path)
-    return localfs(path)
+
+    # localfs('file.sgy') => '.'
+    # localfs('dir1/file.sgy') => 'dir1'
+    # localfs('dir1') => 'dir1'
+    #
+    # inputs tend to be files and output tend to be directories, but both input
+    # and output can use the localfs_from_args helper.
+    if path.is_file():
+        return localfs(path.parent)
+    else:
+        return localfs(path)
 
 def get_blob_path(url):
     """

--- a/python/oneseismic/internal/test_argparse.py
+++ b/python/oneseismic/internal/test_argparse.py
@@ -5,3 +5,10 @@ def test_localfs_root_from_args():
     assert localfs_from_args(None).root   == Path('.')
     assert localfs_from_args('/usr').root == Path('/usr')
     assert localfs_from_args('rel').root  == Path('.') / Path('rel')
+
+def test_localfs_file_arg_gets_dir(tmp_path):
+    (tmp_path / 'some-file').touch()
+    fs = localfs_from_args(tmp_path / 'some-file')
+    assert fs.root == tmp_path
+    with fs.open('some-file', 'rb'):
+        pass


### PR DESCRIPTION
The localfs_from_args helper is used both when setting up input (usually
a file name) and output (usually a directory), but when used like this:

    oneseismic scan file.sgy

it would try to open file.sgy/file.sgy, which is wrong. localfs supplies
open() and really work on directories, so infer the directory from the
path even when it is a file.