### PR TITLE
Revised manifest and attributes

### DIFF
--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -137,7 +137,7 @@ func asSliceSliceInt32(root interface{}) ([][]int32, error) {
 }
 
 func (c *cube) Linenumbers(ctx context.Context) ([][]int32, error) {
-	doc, ok := c.manifest["dimensions"]
+	doc, ok := c.manifest["line-numbers"]
 	if !ok {
 		keys := ctx.Value("keys").(map[string]string)
 		pid  := keys["pid"]

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -31,8 +31,26 @@ struct not_found : public std::out_of_range {
     using std::out_of_range::out_of_range;
 };
 
+struct volumedesc {
+    std::string prefix; /* e.g. src/, attributes/ */
+    std::string ext;    /* file-extension */
+    std::vector< std::vector< int > > shapes;
+};
+
+struct attributedesc {
+    std::string prefix; /* e.g. src/, attributes/ */
+    std::string ext;    /* file-extension */
+    std::string type;   /* e.g. cdp, utm */
+    std::string layout; /* e.g. tiled */
+    std::vector< std::string > labels;
+    std::vector< std::vector< int > > shapes;
+};
+
 struct manifestdoc {
-    std::vector< std::vector< int > > dimensions;
+    std::vector< volumedesc >           vol;
+    std::vector< attributedesc >        attr;
+    std::vector< std::vector< int > >   line_numbers;
+    std::vector< std::string >          line_labels;
 };
 
 /*
@@ -61,8 +79,8 @@ struct basic_task {
         shape            (q.shape),
         function         (q.function)
     {
-        this->shape_cube.reserve(q.manifest.dimensions.size());
-        for (const auto& d : q.manifest.dimensions)
+        this->shape_cube.reserve(q.manifest.line_numbers.size());
+        for (const auto& d : q.manifest.line_numbers)
             this->shape_cube.push_back(d.size());
     }
 

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -23,6 +23,10 @@ class bad_message : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
+class bad_document : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
 class bad_value : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -89,15 +89,6 @@ void to_json(nlohmann::json& doc, const attributedesc& a) noexcept (false) {
 }
 
 void from_json(const nlohmann::json& doc, manifestdoc& m) noexcept (false) {
-    if (doc.at("format-version") != 1) {
-        const auto msg = fmt::format(
-            "expected format-version {}, was {}",
-            1,
-            int(doc.at("format-version"))
-        );
-        throw bad_message(msg);
-    }
-
     doc.at("line-numbers").get_to(m.line_numbers);
     doc.at("line-labels") .get_to(m.line_labels);
     doc.at("data")        .get_to(m.vol);

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -385,6 +385,21 @@ namespace one {
 std::vector< std::string >
 mkschedule(const char* doc, int len, int task_size) noexcept (false) {
     const auto document = nlohmann::json::parse(doc, doc + len);
+    /*
+     * Right now, only format-version: 1 is supported, but checking the format
+     * version allow for multiple document versions to be supported as storage
+     * migrates between the representation. Dispatch here to different
+     * query-builder routines, depending on the format version.
+     */
+    if (document.at("format-version") != 1) {
+        const auto msg = fmt::format(
+            "unsupported format-version; expected {}, was {}",
+            1,
+            int(doc.at("format-version"))
+        );
+        throw bad_document(msg);
+    }
+
     const std::string function = document["function"];
     if (function == "slice") {
         auto slice = schedule_maker< slice_query, slice_task >{};

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -14,7 +14,7 @@
 namespace {
 
 one::gvt< 3 > geometry(const one::basic_query& query) noexcept (false) {
-    const auto& dimensions = query.manifest.dimensions;
+    const auto& dimensions = query.manifest.line_numbers;
     const auto& shape = query.shape;
 
     return one::gvt< 3 > {
@@ -203,7 +203,7 @@ schedule_maker< one::slice_query, one::slice_task >::header(
     const one::slice_query& query,
     int ntasks
 ) noexcept (false) {
-    const auto& mdims = query.manifest.dimensions;
+    const auto& mdims = query.manifest.line_numbers;
     const auto gvt  = geometry(query);
     const auto dim  = gvt.mkdim(query.dim);
     const auto gvt2 = gvt.squeeze(dim);
@@ -279,8 +279,8 @@ schedule_maker< one::curtain_query, one::curtain_task >::build(
     auto task = one::curtain_task(query);
     auto dim0s = query.dim0s;
     auto dim1s = query.dim1s;
-    to_cartesian_inplace(query.manifest.dimensions[0], dim0s);
-    to_cartesian_inplace(query.manifest.dimensions[1], dim1s);
+    to_cartesian_inplace(query.manifest.line_numbers[0], dim0s);
+    to_cartesian_inplace(query.manifest.line_numbers[1], dim1s);
     auto& ids = task.ids;
 
     auto gvt = geometry(query);
@@ -357,7 +357,7 @@ schedule_maker< one::curtain_query, one::curtain_task >::header(
     const one::curtain_query& query,
     int ntasks
 ) noexcept (false) {
-    const auto& mdims = query.manifest.dimensions;
+    const auto& mdims = query.manifest.line_numbers;
 
     one::process_header head;
     head.pid    = query.pid;

--- a/python/oneseismic/upload/upload.py
+++ b/python/oneseismic/upload/upload.py
@@ -57,8 +57,7 @@ class fileset:
     Right now, oneseismic is not mature enough to properly handle "holes" in
     the volumes, and require explicit padding.  The fileset class is aware of
     this and will generate padding fragments when necessary. This may change in
-    the future and should not be relied on. However, uploading programs should
-    be written so it they are oblivious to this.
+    the future and should not be relied on.
     """
     def __init__(self, key1s, key2s, key3s, fragment_shape):
         mkfile = lambda: np.zeros(shape = fragment_shape, dtype = np.float32)

--- a/python/oneseismic/upload/upload.py
+++ b/python/oneseismic/upload/upload.py
@@ -194,6 +194,10 @@ def upload(manifest, fragment_shape, src, filesys):
     key3s = manifest['dimensions'][2]
     guid  = manifest['guid']
 
+    key1s.sort()
+    key2s.sort()
+    key3s.sort()
+
     # Seek past the textual headers and the binary header
     src.seek(int(manifest['byteoffset-first-trace']), io.SEEK_CUR)
 
@@ -237,6 +241,28 @@ def upload(manifest, fragment_shape, src, filesys):
             print('uploading', name)
             with filesys.open(name, mode = 'wb') as f:
                 f.write(fragment)
+
+    manifest = {
+        'format-version': 1,
+        'guid': guid,
+        'data': [
+            {
+                'file-extension': 'f32',
+                'filters': [],
+                'shapes': [list(fragment_shape)],
+                'prefix': 'src',
+                'resolution': 'source',
+            },
+        ],
+        'attributes': [
+        ],
+        'line-numbers': [
+            key1s,
+            key2s,
+            key3s,
+        ],
+        'line-labels': ['inline', 'crossline', 'depth'],
+    }
 
     with filesys.open('manifest.json', mode = 'wb') as f:
         f.write(json.dumps(manifest).encode())

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -5,7 +5,7 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 license = LGPL-3.0
 url = https://github.com/equinor/oneseismic
-version = 0.2.0
+version = 0.2.1
 
 [options]
 packages =


### PR DESCRIPTION
The manifest has for a very long time just been a copy of the scan
output, and used only to store the line numbers for a volume, but was
always intended to be the source of a richer set of parameters and
metadata. Since the rest of oneseismic has been too immature to leverage
a beefier manifest, it was never a priority, but we have reached the
point where it will be useful.

I would like to emphasize that I do not think this is a complete and
final "specification" for format-version 1, and that I expect a little
bit of a churn as we discover opportunities and problems.

Motivation
----------
This is a typical manifest so far:

    {
      "byteorder": "big",
      "format": 1,
      "samples": 5,
      "sampleinterval": 5000,
      "byteoffset-first-trace": 3600,
      "guid": "c26ff223460fb33230d2cb17bd2cdb95",
      "dimensions": [
        [
          5289,
          5290,
          5291,
        ],
          8361,
          8363,
          8365,
          8367,
        ],
        [
          0,
          5000,
          10000,
          15000,
          20000,
        ]
      ]
    }

Of all the data in here, only the guid and dimensions fields are
interesting, and it leaves a lot to be desired, for example:

* What are the available resolutions?
* What are the available partitions/fragmentations?
* Are there filters applied (e.g. compression)?
* Where is the survey?
* Are there other attributes (e.g. UTM coordinates) available?

The new design
--------------
The new design aims to capture all the things that oneseismic would want
to use to realise a query. Here is an example document:

    {
      "format-version": 1,
      "guid": "0d235a7138104e00c421e63f5e3261bf2dc3254b",
      "data": [
        {
          "file-extension": "f32",
          "filters": [],
          "shapes": [[64, 64, 64]],
          "prefix": "src",
          "resolution": "source"
        }
      ],
      "attributes": [
        {
          "type": "cdp",
          "layout":
          "tiled",
          "file-extension": "2f32",
          "labels": ["CDP X", "CDP Y"],
          "shapes": [[256, 512]],
          "prefix": "cdp"
        }
      ],
      "line-numbers": [
        [5289, 5290, 5291],
        [8361, 8363, 8365, 8367],
        [0, 5000, 10000, 15000, 20000]
      ],
      "line-labels": ["inline", "crossline", "depth"]
    }

The document includes a "format-version", which will allow gradual
migration and even concurrent format versions. This is a useful tool for
developing the format specification and gradually migrate data.

Rather than the data being implicit in "src/<partition>/<data.f32>",
this is now an explicit entry in an array of layouts. This is a
mechanism for oneseismic to decide what partitioning and resolution to
use, and makes it more robust w.r.t. paths. I expect that for most
volumes only one partitioning and one resolution would be available, but
this gives a useful tool for picking different layouts for different
needs.

The attributes key is new, and is intended for per-trace attributes such
as coordinates. The goal is for the entries to be self-descriptive and
support all kinds of attributes. Briefly, it opens up for queries like
this:

    {
      cube(id: ...) {
        sliceByIndex(dim: 0, index: 50, opts: { attributes: ["utm"] })
      }
    }

Which would include the UTM coordinates for the traces in the slice with
in the result package, should it be available.

Per-trace attributes can be stored and partitioned as a "squeezed"/flat
volume, and can be fetched and extracted using mostly the same
functionality as oneseismic already provides for volumes.

The "dimensions" key has been renamed to "line-numbers", and
"line-labels" is an explicit entry on the root. Line numbers are special
because all volumes need good line numbers, but they are quite local to
the file (unlike coordinates which usually are global). Line numbers can
also be stored as the set-of-numbers in either dimension, but this is
not a property of most attributes [0].

I considered making line-numbers just any other attribute, but nested
structures are less ergonomic to work with.

Conclusion
----------
All in all this makes the manifest a lot more powerful, with a natural
way of representing various layouts and attributes, and for data missing
or not yet supported by a specific version.

This patch only adds parsing (and upload) for the new manifest
prototype, but otherwise no new functionality is introduced - support
for the new manifest capabilities can be gradually added.

Absent from the patch is a migration strategy and script, but it is
really just a tiny program that fetches the (old) manifest, maps it onto
the new structure, and uploads it to the same address.

[0] for example, if the grid is even slightly rotated or squeezed, then
    coordinates can not be represented as the cartesian product of the
    unique values in all directions