### PR TITLE
Add attribute-query support

### DIFF
--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -269,7 +269,6 @@ func (c *cube) basicSlice(
 		Guid:            string(c.id),
 		Manifest:        c.manifest,
 		StorageEndpoint: c.root.endpoint,
-		Shape:           []int32{ 64, 64, 64 },
 		Function:        "slice",
 		Args:            args,
 	}
@@ -327,7 +326,6 @@ func (c *cube) Curtain(
 		Guid:            string(c.id),
 		Manifest:        c.manifest,
 		StorageEndpoint: c.root.endpoint,
-		Shape:           []int32{ 64, 64, 64 },
 		Function:        "curtain",
 		Args:            args,
 	}

--- a/api/api/result.go
+++ b/api/api/result.go
@@ -51,6 +51,7 @@ func resultFromProcessHeader(
 		Bundles: head.Ntasks,
 		Shape:   head.Shape,
 		Index:   head.Index,
+		Attrs:   head.Attrs,
 	}
 }
 

--- a/api/api/scheduler.cpp
+++ b/api/api/scheduler.cpp
@@ -17,24 +17,9 @@ char* copy(char* dst, const T& x) noexcept (true) {
 
 }
 
-plan mkschedule(const char* doc, int len, int task_size) {
+plan mkschedule(const char* doc, int len, int task_size) try {
     plan p {};
-    std::vector< std::string > packed;
-    try {
-        packed = one::mkschedule(doc, len, task_size);
-    } catch (one::not_found& e) {
-        p.status_code = 404;
-        auto* err = new char[std::strlen(e.what()) + 1];
-        std::strcpy(err, e.what());
-        p.err = err;
-        return p;
-    } catch (std::exception& e) {
-        p.status_code = 500;
-        auto* err = new char[std::strlen(e.what()) + 1];
-        std::strcpy(err, e.what());
-        p.err = err;
-        return p;
-    }
+    const auto packed = one::mkschedule(doc, len, task_size);
 
     const auto flat_tasksize = std::accumulate(
         packed.begin(),
@@ -58,6 +43,13 @@ plan mkschedule(const char* doc, int len, int task_size) {
         dst = copy(dst, packed[i]);
     }
 
+    return p;
+} catch (std::exception& e) {
+    plan p {};
+    p.status_code = 500;
+    auto* err = new char[std::strlen(e.what()) + 1];
+    std::strcpy(err, e.what());
+    p.err = err;
     return p;
 }
 

--- a/api/api/scheduler.go
+++ b/api/api/scheduler.go
@@ -96,9 +96,10 @@ func (sched *cppscheduler) MakeQuery(query *message.Query) (*QueryPlan, error) {
 		this += uintptr(size)
 	}
 
+	headerindex := len(result) - 1
 	return &QueryPlan {
-		header: result[0],
-		plan:   result[1:],
+		header: result[headerindex],
+		plan:   result[:headerindex],
 	}, nil
 }
 

--- a/api/api/scheduler.go
+++ b/api/api/scheduler.go
@@ -67,15 +67,15 @@ func newScheduler(storage redis.Cmdable) scheduler {
 	}
 }
 
-func (sched *cppscheduler) MakeQuery(msg *message.Query) (*QueryPlan, error) {
-	task, err := msg.Pack()
+func (sched *cppscheduler) MakeQuery(query *message.Query) (*QueryPlan, error) {
+	msg, err := query.Pack()
 	if err != nil {
 		return nil, fmt.Errorf("pack error: %w", err)
 	}
 	// TODO: exhaustive error check including those from C++ exceptions
 	csched := C.mkschedule(
-		(*C.char)(unsafe.Pointer(&task[0])),
-		C.int(len(task)),
+		(*C.char)(unsafe.Pointer(&msg[0])),
+		C.int(len(msg)),
 		C.int(sched.tasksize),
 	)
 	defer C.cleanup(&csched)

--- a/api/cmd/fetch/tasks.cpp
+++ b/api/cmd/fetch/tasks.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 #include <string>
 
-#include <oneseismic/geometry.hpp>
 #include <oneseismic/messages.hpp>
 #include <oneseismic/process.hpp>
 

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -24,6 +24,7 @@ type Query struct {
 	StorageEndpoint string       `json:"storage_endpoint"`
 	Function        string       `json:"function"`
 	Args            interface {} `json:"args"`
+	Opts            interface {} `json:"opts"`
 }
 
 func (msg *Query) Pack() ([]byte, error) {

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -131,6 +131,12 @@ type ProcessHeader struct {
 	 * language-specific index like in xarray in python.
 	 */
 	Index [][]int `json:"index"`
+	/*
+	 * The attributes included in the request, such as cdpx, cdpy, cdpm etc.
+	 * Getting attributes is just another task, but this is a parsing hint for
+	 * the assembler.
+	 */
+	Attrs []string `json:"attributes"`
 }
 
 func (m *ProcessHeader) Pack() ([]byte, error) {
@@ -150,6 +156,7 @@ type ResultHeader struct {
 	Bundles int
 	Shape   []int
 	Index   [][]int
+	Attrs   []string
 }
 
 /*
@@ -164,13 +171,14 @@ func (rh *ResultHeader) Pack() ([]byte, error) {
 	if err := enc.EncodeArrayLen(2); err != nil {
 		return nil, err
 	}
-	if err := enc.EncodeMapLen(3); err != nil {
+	if err := enc.EncodeMapLen(4); err != nil {
 		return nil, err
 	}
 	err := enc.EncodeMulti(
-		"bundles", rh.Bundles,
-		"shape",   rh.Shape,
-		"index",   rh.Index,
+		"bundles",    rh.Bundles,
+		"shape",      rh.Shape,
+		"index",      rh.Index,
+		"attributes", rh.Attrs,
 	)
 	if err != nil {
 		return nil, err

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -38,14 +38,15 @@ func (msg *Query) Unpack(doc []byte) (*Query, error) {
  * Corresponds to basic_task and derivatives in oneseismic/messages.hpp, and
  * is read from the worker nodes when performing a task, which combined makes
  * up a process.
+
+ * Only the useful (to go) fields are parsed - the actual document has more
+ * fields.
  */
 type Task struct {
 	Pid             string       `json:"pid"`
 	Token           string       `json:"token"`
 	Guid            string       `json:"guid"`
 	StorageEndpoint string       `json:"storage_endpoint"`
-	Shape           []int32      `json:"shape"`
-	ShapeCube       []int32      `json:"shape-cube"`
 	Function        string       `json:"function"`
 }
 

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -22,7 +22,6 @@ type Query struct {
 	Guid            string       `json:"guid"`
 	Manifest        interface {} `json:"manifest"`
 	StorageEndpoint string       `json:"storage_endpoint"`
-	Shape           []int32      `json:"shape"`
 	Function        string       `json:"function"`
 	Args            interface {} `json:"args"`
 }

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -35,7 +35,6 @@ set(CMAKE_CXX_STANDARD 14)
 
 add_library(oneseismic
     src/base64.cpp
-    src/geometry.cpp
     src/messages.cpp
     src/plan.cpp
     src/process.cpp

--- a/core/include/oneseismic/geometry.hpp
+++ b/core/include/oneseismic/geometry.hpp
@@ -3,7 +3,6 @@
 
 #include <array>
 #include <cassert>
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -530,5 +529,7 @@ class gvt {
 };
 
 }
+
+#include <oneseismic/geometry.impl.hpp>
 
 #endif //ONESEISMIC_GEOMETRY_HPP

--- a/core/include/oneseismic/geometry.hpp
+++ b/core/include/oneseismic/geometry.hpp
@@ -470,7 +470,7 @@ class gvt {
          * *fragment*, not the line.
          */
         std::vector< FID< ND > >
-        slice(Dimension dim, std::size_t n) noexcept (false);
+        slice(Dimension dim, std::size_t n) const noexcept (false);
 
         /*
          * The slice layout for putting a single fragment into a cube

--- a/core/include/oneseismic/geometry.hpp
+++ b/core/include/oneseismic/geometry.hpp
@@ -307,6 +307,7 @@ template< std::size_t ND >
 struct CS : public basic_tuple< CS< ND >, ND > {
     using base_type = basic_tuple< CS, ND >;
     using base_type::base_type;
+    using Dimension = dimension< ND >;
 
     std::size_t to_offset(CP< ND >)  const noexcept (true);
     std::size_t to_offset(FID< ND >) const noexcept (true);
@@ -323,8 +324,36 @@ template< std::size_t ND >
 struct FS : public basic_tuple< FS< ND >, ND > {
     using base_type = basic_tuple< FS, ND >;
     using base_type::base_type;
+    using Dimension = dimension< ND >;
 
     std::size_t to_offset(FP< ND >) const noexcept (true);
+    /*
+     * Find the fragment-local dimension index that the global index
+     * intersects. This is similar to to_offset, but for planes. This function
+     * helps map from the global slice index (the query) to the local slice
+     * index (used in extraction).
+     *
+     * Example:
+     * Consider a 4x6x8 cube shape, made up of 2x3x4 fragments, and the index
+     * 3.
+     *
+     * if dim = 0, the fragments are intersected at index 1
+     * if dim = 1, the fragments are intersected at index 0
+     * if dim = 2, the fragments are intersected at index 3
+     *
+     *
+     * Effectively, queries to gvt goes:
+     *
+     *     sliceByIndex(dim: D, index: N)
+     *
+     * But downstream, when individual fragments are fetched, the extraction
+     * goes:
+     *
+     *     getSlice(dim: D, index: local(N))
+     *
+     * and index() provides this local() function.
+     */
+    std::size_t index(Dimension, std::size_t) const noexcept (true);
     std::size_t slice_samples(dimension< ND >) const noexcept (true);
     slice_layout slice_stride(dimension< ND >) const noexcept (false);
     FS< ND - 1 > squeeze(dimension< ND >) const noexcept (true);

--- a/core/include/oneseismic/geometry.impl.hpp
+++ b/core/include/oneseismic/geometry.impl.hpp
@@ -303,7 +303,7 @@ void cartesian_product(
 
 template < std::size_t ND >
 std::vector< FID< ND > >
-gvt< ND >::slice(Dimension dim, std::size_t no) noexcept (false) {
+gvt< ND >::slice(Dimension dim, std::size_t no) const noexcept (false) {
     /*
      * A fairly straight-forward (although a bit slower than it had to) way of
      * getting the fragment IDs that slice a cube. Not quite as fast as it

--- a/core/include/oneseismic/geometry.impl.hpp
+++ b/core/include/oneseismic/geometry.impl.hpp
@@ -408,6 +408,12 @@ const noexcept (true) {
 }
 
 template < std::size_t ND >
+std::size_t FS< ND >::index(dimension< ND > d, std::size_t idx)
+const noexcept (true) {
+    return idx % (*this)[d];
+}
+
+template < std::size_t ND >
 slice_layout FS< ND >::slice_stride(dimension< ND > d)
 const noexcept (false) {
     slice_layout s;

--- a/core/include/oneseismic/geometry.impl.hpp
+++ b/core/include/oneseismic/geometry.impl.hpp
@@ -1,7 +1,9 @@
+#ifndef ONESEISMIC_GEOMETRY_IMPL_HPP
+#define ONESEISMIC_GEOMETRY_IMPL_HPP
+
 #include <algorithm>
 #include <cassert>
 #include <functional>
-#include <iostream>
 #include <numeric>
 #include <vector>
 
@@ -444,14 +446,6 @@ const noexcept (true) {
     return one::squeeze(d, *this);
 }
 
-template class gvt< 3 >;
-template class gvt< 2 >;
-template class CS < 3 >;
-template class CS < 2 >;
-template class FS < 3 >;
-template class FID < 3 >;
-template class FID < 2 >;
-template class basic_tuple< FID< 3 >, 3 >;
-template class basic_tuple< FS < 3 >, 3 >;
-
 }
+
+#endif //ONESEISMIC_GEOMETRY_IMPL_HPP

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -110,6 +110,23 @@ struct basic_task {
             this->shape_cube.push_back(d.size());
     }
 
+    basic_task(const basic_query& q, const attributedesc& attr) :
+        pid              (q.pid),
+        token            (q.token),
+        guid             (q.guid),
+        prefix           (attr.prefix),
+        ext              (attr.ext),
+        storage_endpoint (q.storage_endpoint),
+        shape            (attr.shapes.at(0)),
+        function         (q.function),
+        attribute        (attr.type)
+    {
+        this->shape_cube.reserve(q.manifest.line_numbers.size());
+        for (const auto& d : q.manifest.line_numbers)
+            this->shape_cube.push_back(d.size());
+        this->shape_cube.back() = 1;
+    }
+
     std::string        pid;
     std::string        token;
     std::string        guid;
@@ -157,6 +174,11 @@ struct slice_task : public basic_task, Packable< slice_task > {
     slice_task() = default;
     explicit slice_task(const slice_query& q) :
         basic_task(q),
+        dim(q.dim)
+    {}
+
+    slice_task(const slice_query& q, const attributedesc& attr) :
+        basic_task(q, attr),
         dim(q.dim)
     {}
 

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -200,6 +200,7 @@ struct slice_tiles : public MsgPackable< slice_tiles > {
     /*
      * The shape of the slice itself
      */
+    std::string attr;
     std::vector< int > shape;
     std::vector< tile > tiles;
 };

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -64,12 +64,13 @@ struct manifestdoc {
  * their job.
  */
 struct basic_query {
-    std::string        pid;
-    std::string        token;
-    std::string        guid;
-    manifestdoc        manifest;
-    std::string        storage_endpoint;
-    std::string        function;
+    std::string                 pid;
+    std::string                 token;
+    std::string                 guid;
+    manifestdoc                 manifest;
+    std::string                 storage_endpoint;
+    std::string                 function;
+    std::vector< std::string >  attributes;
 
     const std::vector< int >& shape() const noexcept (false) {
         /*
@@ -101,7 +102,8 @@ struct basic_task {
         ext              (q.manifest.vol.at(0).ext),
         storage_endpoint (q.storage_endpoint),
         shape            (q.shape()),
-        function         (q.function)
+        function         (q.function),
+        attribute        ("data")
     {
         this->shape_cube.reserve(q.manifest.line_numbers.size());
         for (const auto& d : q.manifest.line_numbers)
@@ -117,6 +119,7 @@ struct basic_task {
     std::vector< int > shape;
     std::vector< int > shape_cube;
     std::string        function;
+    std::string        attribute;
 };
 
 /*
@@ -131,10 +134,11 @@ struct basic_task {
  * parameters.
  */
 struct process_header : Packable< process_header > {
-    std::string        pid;
-    int                ntasks;
-    std::vector< int > shape;
-    std::vector< std::vector< int > > index;
+    std::string                         pid;
+    int                                 ntasks;
+    std::vector< int >                  shape;
+    std::vector< std::vector< int > >   index;
+    std::vector< std::string >          attributes;
 };
 
 struct slice_query : public basic_query, Packable< slice_query > {

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -97,6 +97,8 @@ struct basic_task {
         pid              (q.pid),
         token            (q.token),
         guid             (q.guid),
+        prefix           (q.manifest.vol.at(0).prefix),
+        ext              (q.manifest.vol.at(0).ext),
         storage_endpoint (q.storage_endpoint),
         shape            (q.shape()),
         function         (q.function)
@@ -110,6 +112,8 @@ struct basic_task {
     std::string        token;
     std::string        guid;
     std::string        storage_endpoint;
+    std::string        prefix;
+    std::string        ext;
     std::vector< int > shape;
     std::vector< int > shape_cube;
     std::string        function;

--- a/core/include/oneseismic/plan.hpp
+++ b/core/include/oneseismic/plan.hpp
@@ -9,8 +9,11 @@
 
 namespace one {
 
-std::vector< std::string >
-mkschedule(const char* doc, int len, int task_size) noexcept (false);
+std::string mkschedule(
+    const char* doc,
+    int len,
+    int task_size)
+noexcept (false);
 
 }
 

--- a/core/include/oneseismic/process.hpp
+++ b/core/include/oneseismic/process.hpp
@@ -63,10 +63,11 @@ public:
 
 protected:
     /*
-     * Set the fragment shape. This is cleared by clear() and must be set for
-     * every init(). It sets the prefix for fragment-ID generation.
+     * Set the <prefix>/<fragment-shape> parts of the URL. This is cleared by
+     * clear() and must be set for every init(). It sets the prefix for
+     * fragment-ID generation.
      */
-    void set_fragment_shape(const std::string&) noexcept (false);
+    void set_prefix(const basic_task&) noexcept (false);
     /*
      * Register a fragment id, for url generation. Duplicates will not be
      * removed, this is effectively an accumulating ';'.join([prefix + id]...)
@@ -74,7 +75,11 @@ protected:
      * This will be cleared by clear(), which must be called before process
      * handles are re-used.
      */
-    void add_fragment(const std::string& id) noexcept (false);
+    void add_fragment(
+            const std::string& id,
+            const std::string& ext)
+    noexcept (false);
+
     void clear() noexcept (true);
 
 private:

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -125,6 +125,8 @@ void to_json(nlohmann::json& doc, const basic_task& task) noexcept (false) {
     doc["token"]            = task.token;
     doc["guid"]             = task.guid;
     doc["storage_endpoint"] = task.storage_endpoint;
+    doc["prefix"]           = task.prefix;
+    doc["ext"]              = task.ext;
     doc["shape"]            = task.shape;
     doc["shape-cube"]       = task.shape_cube;
     doc["function"]         = task.function;
@@ -136,6 +138,8 @@ void from_json(const nlohmann::json& doc, basic_task& task) noexcept (false) {
     doc.at("token")           .get_to(task.token);
     doc.at("guid")            .get_to(task.guid);
     doc.at("storage_endpoint").get_to(task.storage_endpoint);
+    doc.at("prefix")          .get_to(task.prefix);
+    doc.at("ext")             .get_to(task.ext);
     doc.at("shape")           .get_to(task.shape);
     doc.at("shape-cube")      .get_to(task.shape_cube);
     doc.at("function")        .get_to(task.function);

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -108,7 +108,6 @@ void to_json(nlohmann::json& doc, const basic_query& query) noexcept (false) {
     doc["guid"]             = query.guid;
     doc["manifest"]         = query.manifest;
     doc["storage_endpoint"] = query.storage_endpoint;
-    doc["shape"]            = query.shape;
     doc["function"]         = query.function;
 }
 
@@ -118,7 +117,6 @@ void from_json(const nlohmann::json& doc, basic_query& query) noexcept (false) {
     doc.at("guid")            .get_to(query.guid);
     doc.at("manifest")        .get_to(query.manifest);
     doc.at("storage_endpoint").get_to(query.storage_endpoint);
-    doc.at("shape")           .get_to(query.shape);
     doc.at("function")        .get_to(query.function);
 }
 

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -289,13 +289,15 @@ void from_json(const nlohmann::json& doc, tile& tile) noexcept (false) {
 }
 
 void to_json(nlohmann::json& doc, const slice_tiles& tiles) noexcept (false) {
-    doc["shape"] = tiles.shape;
-    doc["tiles"] = tiles.tiles;
+    doc["attribute"]  = tiles.attr;
+    doc["shape"]      = tiles.shape;
+    doc["tiles"]      = tiles.tiles;
 }
 
 void from_json(const nlohmann::json& doc, slice_tiles& tiles) noexcept (false) {
-    doc.at("shape").get_to(tiles.shape);
-    doc.at("tiles").get_to(tiles.tiles);
+    doc.at("attribute").get_to(tiles.attr);
+    doc.at("shape")    .get_to(tiles.shape);
+    doc.at("tiles")    .get_to(tiles.tiles);
 }
 
 void to_json(nlohmann::json& doc, const single& single) noexcept (false) {

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -109,6 +109,7 @@ void to_json(nlohmann::json& doc, const basic_query& query) noexcept (false) {
     doc["manifest"]         = query.manifest;
     doc["storage_endpoint"] = query.storage_endpoint;
     doc["function"]         = query.function;
+    doc["attributes"]       = query.attributes;
 }
 
 void from_json(const nlohmann::json& doc, basic_query& query) noexcept (false) {
@@ -118,6 +119,15 @@ void from_json(const nlohmann::json& doc, basic_query& query) noexcept (false) {
     doc.at("manifest")        .get_to(query.manifest);
     doc.at("storage_endpoint").get_to(query.storage_endpoint);
     doc.at("function")        .get_to(query.function);
+
+    const auto optsitr = doc.find("opts");
+    if (optsitr == doc.end()) return;
+
+    const auto& opts = *optsitr;
+
+    const auto attr = opts.find("attributes");
+    if (attr != opts.end())
+        attr->get_to(query.attributes);
 }
 
 void to_json(nlohmann::json& doc, const basic_task& task) noexcept (false) {
@@ -130,6 +140,7 @@ void to_json(nlohmann::json& doc, const basic_task& task) noexcept (false) {
     doc["shape"]            = task.shape;
     doc["shape-cube"]       = task.shape_cube;
     doc["function"]         = task.function;
+    doc["attribute"]        = task.attribute;
     assert(task.shape_cube.size() == task.shape.size());
 }
 
@@ -143,20 +154,23 @@ void from_json(const nlohmann::json& doc, basic_task& task) noexcept (false) {
     doc.at("shape")           .get_to(task.shape);
     doc.at("shape-cube")      .get_to(task.shape_cube);
     doc.at("function")        .get_to(task.function);
+    doc.at("attribute")       .get_to(task.attribute);
 }
 
 void to_json(nlohmann::json& doc, const process_header& head) noexcept (false) {
-    doc["pid"]    = head.pid;
-    doc["ntasks"] = head.ntasks;
-    doc["shape"]  = head.shape;
-    doc["index"]  = head.index;
+    doc["pid"]          = head.pid;
+    doc["ntasks"]       = head.ntasks;
+    doc["shape"]        = head.shape;
+    doc["index"]        = head.index;
+    doc["attributes"]   = head.attributes;
 }
 
 void from_json(const nlohmann::json& doc, process_header& head) noexcept (false) {
-    doc.at("pid")   .get_to(head.pid);
-    doc.at("ntasks").get_to(head.ntasks);
-    doc.at("shape") .get_to(head.shape);
-    doc.at("index") .get_to(head.index);
+    doc.at("pid")       .get_to(head.pid);
+    doc.at("ntasks")    .get_to(head.ntasks);
+    doc.at("shape")     .get_to(head.shape);
+    doc.at("index")     .get_to(head.index);
+    doc.at("attributes").get_to(head.attributes);
 }
 
 void from_json(const nlohmann::json& doc, slice_query& query) noexcept (false) {

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -13,9 +13,9 @@
 
 namespace {
 
-one::gvt< 3 > geometry(const one::basic_query& query) noexcept (false) {
+one::gvt< 3 > geometry( const one::basic_query& query) noexcept (false) {
     const auto& dimensions = query.manifest.line_numbers;
-    const auto& shape = query.shape;
+    const auto& shape = query.shape();
 
     return one::gvt< 3 > {
         { dimensions[0].size(),

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -63,6 +63,29 @@ std::string& append(std::string& list, const std::string& elem) {
     return list;
 }
 
+template < typename Query >
+std::vector< std::string > normalized_attributes(const Query& q) {
+    std::vector< std::string > attrs;
+    attrs.reserve(q.attributes.size() * 2);
+
+    for (const auto& attr : q.attributes) {
+        if (attr == "cdp") {
+            attrs.push_back("cdpx");
+            attrs.push_back("cdpy");
+        } else {
+            attrs.push_back(attr);
+        }
+    };
+
+    std::sort(attrs.begin(), attrs.end());
+    attrs.erase(
+        std::unique(attrs.begin(), attrs.end()),
+        attrs.end()
+    );
+
+    return attrs;
+}
+
 /*
  * Scheduling
  * ----------
@@ -208,6 +231,7 @@ std::string schedule_maker< Input, Output >::schedule(
 noexcept (false) {
     Input in;
     in.unpack(doc, doc + len);
+    in.attributes = normalized_attributes(in);
     auto fetch = this->build(in);
     auto sched = this->partition(fetch, task_size);
 

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -225,8 +225,9 @@ schedule_maker< one::slice_query, one::slice_task >::header(
     const auto fs2  = gvt2.fragment_shape();
 
     one::process_header head;
-    head.pid    = query.pid;
-    head.ntasks = ntasks;
+    head.pid        = query.pid;
+    head.ntasks     = ntasks;
+    head.attributes = query.attributes;
 
     /*
      * The shape of a slice are the dimensions of the survey squeezed in that
@@ -375,8 +376,9 @@ schedule_maker< one::curtain_query, one::curtain_task >::header(
     const auto& mdims = query.manifest.line_numbers;
 
     one::process_header head;
-    head.pid    = query.pid;
-    head.ntasks = ntasks;
+    head.pid        = query.pid;
+    head.ntasks     = ntasks;
+    head.attributes = query.attributes;
 
     const auto gvt  = geometry(query);
     const auto zpad = gvt.nsamples_padded(gvt.mkdim(gvt.ndims - 1));

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -121,6 +121,7 @@ void slice::init(const char* msg, int len) {
     this->clear();
     this->input.unpack(msg, msg + len);
     this->output.tiles.resize(this->input.ids.size());
+    this->output.attr = this->input.attribute;
 
     const auto g3 = gvt3(this->input);
     const auto& fragment_shape = g3.fragment_shape();

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -115,6 +115,8 @@ const std::string& proc::fragments() const {
     return this->frags;
 }
 
+namespace {
+
 void slice::init(const char* msg, int len) {
     this->clear();
     this->input.unpack(msg, msg + len);
@@ -241,6 +243,8 @@ void curtain::add(int key, const char* chunk, int len) {
 
 std::string curtain::pack() {
     return this->output.pack();
+}
+
 }
 
 }

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -124,16 +124,12 @@ void slice::init(const char* msg, int len) {
 
     const auto g3 = gvt3(this->input);
     const auto& fragment_shape = g3.fragment_shape();
-    const auto& cube_shape     = g3.cube_shape();
 
     this->set_prefix(this->input);
     this->dim = g3.mkdim(this->input.dim);
     this->idx = this->input.idx;
     this->layout = fragment_shape.slice_stride(this->dim);
-    this->gvt = one::gvt< 2 >(
-        cube_shape.squeeze(this->dim),
-        fragment_shape.squeeze(this->dim)
-    );
+    this->gvt = g3.squeeze(this->dim);
 
     const auto& cs = this->gvt.cube_shape();
     this->output.shape.assign(cs.begin(), cs.end());

--- a/core/tests/geometry.cpp
+++ b/core/tests/geometry.cpp
@@ -89,6 +89,14 @@ SCENARIO( "Converting between global and local coordinates" ) {
     }
 }
 
+TEST_CASE("Global slice indices are mapped to fragment-local indices") {
+    const auto fs = one::FS< 3 > { 2, 3, 4 };
+    using Dim = one::FS< 3 >::Dimension;
+    CHECK(fs.index(Dim(0), 3) == 1);
+    CHECK(fs.index(Dim(1), 3) == 0);
+    CHECK(fs.index(Dim(2), 3) == 3);
+}
+
 TEST_CASE("Squeezing gvt") {
     const auto original = one::gvt< 3 >(
         one::CS< 3 >(6, 9, 18),

--- a/core/tests/messages.cpp
+++ b/core/tests/messages.cpp
@@ -88,7 +88,6 @@ TEST_CASE("well-formed slice-query is unpacked correctly") {
             "line-numbers": [[10]],
             "line-labels": ["dim-0"]
         },
-        "shape": [64, 64, 64],
         "function": "slice",
         "args": {
             "kind": "lineno",
@@ -114,7 +113,6 @@ TEST_CASE("well-formed slice-query is unpacked correctly") {
     CHECK(query.guid  == "object-id");
     CHECK(query.manifest == manifest);
     CHECK(query.storage_endpoint == "https://storage.com");
-    CHECK_THAT(query.shape,      Equals(std::vector< int >{ 64,  64,  64}));
     CHECK(query.dim == 0);
     CHECK(query.idx == 0);
 }

--- a/core/tests/process.cpp
+++ b/core/tests/process.cpp
@@ -8,9 +8,11 @@ using namespace Catch::Matchers;
 
 one::slice_task default_slice_task() {
     one::slice_task input;
-    input.pid   = "some-pid";
-    input.token = "some-token";
-    input.guid  = "some-guid";
+    input.pid    = "some-pid";
+    input.token  = "some-token";
+    input.guid   = "some-guid";
+    input.prefix = "src";
+    input.ext    = "f32";
 
     input.storage_endpoint = "some-endpoint";
     input.shape      = { 64, 64, 64 };
@@ -156,9 +158,11 @@ TEST_CASE("slice.add is not sensitive to order") {
 
 one::curtain_task default_curtain_task() {
     one::curtain_task input;
-    input.pid   = "some-pid";
-    input.token = "some-token";
-    input.guid  = "some-guid";
+    input.pid    = "some-pid";
+    input.token  = "some-token";
+    input.guid   = "some-guid";
+    input.prefix = "src";
+    input.ext    = "f32";
 
     input.storage_endpoint = "some-endpoint";
     input.shape      = { 64, 64, 64 };

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -68,6 +68,8 @@ class assembler_slice(assembler):
 
         result = np.zeros((dims0 * dims1), dtype = np.single)
         for bundle in unpacked[1]:
+            if bundle.get('attribute') != 'data':
+                continue
             for tile in bundle['tiles']:
                 layout = tile
                 dst = layout['initial-skip']

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -86,12 +86,52 @@ class assembler_slice(assembler):
     def xarray(self, unpacked):
         index = unpacked[0]['index']
         a = self.numpy(unpacked)
+        shape = unpacked[0]['shape']
+
+        dims0 = len(index[0])
+        dims1 = len(index[1])
+
+        attrs = {}
+        for attr in unpacked[0]['attributes']:
+            dtype = 'f4'
+            if self.name.startswith('time'):
+                attrlabels = self.dims
+                attrshape = [dims0, dims1]
+            else:
+                attrlabels = self.dims[0]
+                attrshape = [dims0]
+            attrs[attr] = np.zeros(np.prod(attrshape), dtype = dtype).ravel()
+
+        for bundle in unpacked[1]:
+            if bundle['attribute'] not in attrs:
+                continue
+
+            result = attrs[bundle['attribute']]
+            for tile in bundle['tiles']:
+                layout = tile
+                dst = layout['initial-skip']
+                chunk_size = layout['chunk-size']
+                src = 0
+                v = tile['v']
+                for _ in range(layout['iterations']):
+                    result[dst : dst + chunk_size] = v[src : src + chunk_size]
+                    src += layout['substride']
+                    dst += layout['superstride']
+
         # TODO: add units for time/depth
+        coords = {
+            self.dims[0]: index[0],
+            self.dims[1]: index[1],
+        }
+
+        for k, v in attrs.items():
+            coords[k] = (attrlabels, v.reshape(attrshape))
+
         return xarray.DataArray(
             data   = a,
             dims   = self.dims,
             name   = self.name,
-            coords = index,
+            coords = coords,
         )
 
 class assembler_curtain(assembler):

--- a/python/oneseismic/upload/upload.py
+++ b/python/oneseismic/upload/upload.py
@@ -261,7 +261,7 @@ def upload(manifest, fragment_shape, src, filesys):
             key2s,
             key3s,
         ],
-        'line-labels': ['inline', 'crossline', 'depth'],
+        'line-labels': ['inline', 'crossline', 'time'],
     }
 
     with filesys.open('manifest.json', mode = 'wb') as f:


### PR DESCRIPTION
This PR adds support for attributes. Briefly, attributes are per-trace data, typically coordinates, that can be quite useful sometimes. The motivation is best illustrated with an example. Consider the query

```
{
    cube(id: ...) {
        sliceByLineno(dim: 0, index: 150, opts: { attributes: [cdp] })
    }
}
```

When realised into an xarray, it yields

```
<xarray.DataArray 'inline 10261' (crossline: 720, time: 850)>
array([[ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
         0.0000000e+00,  0.0000000e+00,  0.0000000e+00],
       [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
         0.0000000e+00,  0.0000000e+00,  0.0000000e+00],
       [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
         0.0000000e+00,  0.0000000e+00,  0.0000000e+00],
       ...,
       [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
        -1.1615995e-02,  1.2507305e-02,  0.0000000e+00],
       [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
        -4.3828748e-03,  2.0183403e-02,  0.0000000e+00],
       [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
        -4.2640328e-05,  3.5810769e-02,  0.0000000e+00]], dtype=float32)
Coordinates:
    cdp x      (crossline) float32 1.009e+07 1.009e+07 ... 9.222e+06 9.221e+06
    cdp y      (crossline) float32 1.036e+07 1.036e+07 ... 1.058e+07 1.058e+07
  * crossline  (crossline) int64 1961 1962 1963 1964 ... 2677 2678 2679 2680
  * time       (time) int64 0 4000 8000 12000 ... 3388000 3392000 3396000
```

The PR touches a bunch of files, since attributes were neither uploaded, available in the query language, nor were the scheduling system ready (and there were a couple of drive by fixes).

At a high level, the strategy is to represent attributes as regular, but flat, volumes. This makes them pretty much indistinguishable from the sampled data from oneseismic's point of view, and it folds itself right into the oneseismic pipeline.