### PR TITLE
Pack tiles as tuples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
 
 install:
   - sudo apt-get install -y libzmq3-dev libspdlog-dev
-  - sudo apt-get install -y redis-server redis-server libhiredis-dev
   - wget https://github.com/fmtlib/fmt/releases/download/6.0.0/fmt-6.0.0.zip
   - unzip fmt-6.0.0.zip
   - mkdir -p fmt-6.0.0/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 
 install:
   - sudo apt-get install -y libzmq3-dev libspdlog-dev
+  - sudo apt-get install -y libmsgpack-dev
   - wget https://github.com/fmtlib/fmt/releases/download/6.0.0/fmt-6.0.0.zip
   - unzip fmt-6.0.0.zip
   - mkdir -p fmt-6.0.0/build

--- a/api/api/result.go
+++ b/api/api/result.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -13,7 +12,6 @@ import (
 	"github.com/equinor/oneseismic/api/internal/message"
 	"github.com/go-redis/redis/v8"
 	"github.com/gin-gonic/gin"
-	"github.com/vmihailenco/msgpack/v5"
 )
 
 type Result struct {
@@ -46,15 +44,6 @@ func parseProcessHeader(doc []byte) (*message.ProcessHeader, error) {
 	return ph, nil
 }
 
-func wrap(head* message.ProcessHeader) []byte {
-	var b bytes.Buffer
-	enc := msgpack.NewEncoder(&b)
-	enc.EncodeArrayLen(2)
-	b.Write(head.RawHeader)
-	enc.EncodeArrayLen(head.Ntasks)
-	return b.Bytes()
-}
-
 func collectResult(
 	ctx context.Context,
 	storage redis.Cmdable,
@@ -68,7 +57,7 @@ func collectResult(
 	// and that the transfer is completed.
 	defer close(tiles)
 
-	tiles <- wrap(head)
+	tiles <- head.RawHeader
 
 	streamCursor := "0"
 	count := 0

--- a/api/api/result.go
+++ b/api/api/result.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"github.com/equinor/oneseismic/api/internal/message"
 	"github.com/go-redis/redis/v8"
 	"github.com/gin-gonic/gin"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 type Result struct {
@@ -44,15 +46,13 @@ func parseProcessHeader(doc []byte) (*message.ProcessHeader, error) {
 	return ph, nil
 }
 
-func resultFromProcessHeader(
-	head *message.ProcessHeader,
-) *message.ResultHeader {
-	return &message.ResultHeader {
-		Bundles: head.Ntasks,
-		Shape:   head.Shape,
-		Index:   head.Index,
-		Attrs:   head.Attrs,
-	}
+func wrap(head* message.ProcessHeader) []byte {
+	var b bytes.Buffer
+	enc := msgpack.NewEncoder(&b)
+	enc.EncodeArrayLen(2)
+	b.Write(head.RawHeader)
+	enc.EncodeArrayLen(head.Ntasks)
+	return b.Bytes()
 }
 
 func collectResult(
@@ -68,13 +68,7 @@ func collectResult(
 	// and that the transfer is completed.
 	defer close(tiles)
 
-	rh := resultFromProcessHeader(head)
-	rhpacked, err := rh.Pack()
-	if err != nil {
-		failure <- err
-		return
-	}
-	tiles <- rhpacked
+	tiles <- wrap(head)
 
 	streamCursor := "0"
 	count := 0

--- a/api/api/scheduler.cpp
+++ b/api/api/scheduler.cpp
@@ -9,78 +9,19 @@
 
 #include <oneseismic/plan.hpp>
 
-namespace {
-
-template < typename T >
-char* copy(char* dst, const T& x) noexcept (true) {
-    const auto len = x.size();
-    std::memcpy(dst, x.data(), len);
-    return dst + len;
-}
-
-void find_msg_sizes(
-    const std::string& packed,
-    int elems,
-    int* dst
-) noexcept (false) {
-    /*
-     * Compute the individual sizes of the messages by recording where the
-     * \0 separators are
-     *
-     * The approach is most easily demonstrated with an example:
-     *
-     * aa0bbb0c0dd0
-     *
-     * pos: [2, 6, 8, 11]
-     * len: [2, 3, 1, 2]
-     *
-     * adj-diff: [2 - 0, 6 - 2, 8 - 6, 11 - 8]
-     * adj-diff: [2, 4, 2, 3]
-     *
-     * All elements but the first have an off-by-one because they count the
-     * separator too, which is fixed by making the diff function (lhs-rhs)-1
-     */
-
-    assert(!packed.empty());
-    const auto bad_count = [](auto i, auto elems) {
-        return std::logic_error(
-            "count() found "
-            + std::to_string(elems) + "messages, "
-            + "but find_msg_sizes got npos at elem = " + std::to_string(i)
-        );
-    };
-
-    std::string::size_type pos = 0;
-    for (int i = 0; i < elems; ++i) {
-        pos = packed.find('\0', pos + 1);
-        if (pos == std::string::npos)
-            throw bad_count(i, elems);
-        dst[i] = int(pos);
-    }
-
-    if (pos != packed.size() - 1)
-        throw std::logic_error("find_msg_sizes did not exhaust input");
-    const auto diff_strlen = [](auto x, auto y) noexcept (true) {
-        return (x - y) - 1;
-    };
-    std::adjacent_difference(dst, dst + elems, dst, diff_strlen);
-}
-
-}
-
 plan mkschedule(const char* doc, int len, int task_size) try {
-    const auto packed = one::mkschedule(doc, len, task_size);
-    if (packed.empty()) {
-        throw one::bad_message("packed query should not be empty");
+    const auto taskset = one::mkschedule(doc, len, task_size);
+    if (taskset.empty()) {
+        throw one::bad_message("task-set should not be empty");
     }
 
     plan p {};
     p.status_code = 200;
-    p.len = std::count(packed.begin(), packed.end(), '\0');
-    p.tasks = new char[packed.size()];
+    p.len = taskset.count();
+    p.tasks = new char[taskset.size()];
     p.sizes = new int [p.len];
-    std::remove_copy(packed.begin(), packed.end(), p.tasks, '\0');
-    find_msg_sizes(packed, p.len, p.sizes);
+    std::copy_n(taskset.sizes.begin(),  taskset.count(), p.sizes);
+    std::copy_n(taskset.packed.begin(), taskset.size(),  p.tasks);
     return p;
 } catch (std::exception& e) {
     plan p {};

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -70,17 +70,6 @@ func (m *Manifest) Unpack(doc []byte) (*Manifest, error) {
 	return m, json.Unmarshal(doc, m)
 }
 
-
-type SliceParams struct {
-	Dim    int `json:"dim"`
-	Lineno int `json:"lineno"`
-}
-
-type CurtainParams struct {
-	Dim0s []int `json:"dim0s"`
-	Dim1s []int `json:"dim1s"`
-}
-
 type DimensionDescription struct {
 	Dimension int   `json:"dimension"`
 	Size      int   `json:"size"`

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -146,5 +146,8 @@ func (m *ProcessHeader) Pack() ([]byte, error) {
 
 func (m *ProcessHeader) Unpack(doc []byte) (*ProcessHeader, error) {
 	m.RawHeader = doc
-	return m, msgpack.Unmarshal(doc, m)
+	// Skip the first byte (the envelope), which should always be array-len = 2
+	// but would make the msgpack object incomplete. We only care about the map
+	// that follows immediately after
+	return m, msgpack.Unmarshal(doc[1:], m)
 }

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -99,44 +99,11 @@ func (m *DimensionDescription) Pack() ([]byte, error) {
  */
 type ProcessHeader struct {
 	/*
-	 * The pid for this process. It is usually redundant from the api/result
-	 * perspective since the document itself will be stored (namespaced) with
-	 * the pid as key, but having it easily available is quite useful for other
-	 * parts of the system. Additionally, it can be used to sanity check data
-	 * and request parameters.
-	 */
-	Pid string    `msgpack:"pid"`
-	/*
 	 * The number of separate parts this is broken into, where each part can be
 	 * handled by a separate worker. This is the number of "bundles"
 	 * (parts-of-results) the client will receive.
 	 */
 	Ntasks int    `msgpack:"nbundles"`
-	/*
-	 * The shape of the result *with padding*. It shall always hold that
-	 * shape[n] >= len(index[n]) and len(shape) == len(index). This is an
-	 * advice to clients that they can use to pre-allocate buffers - a buffer
-	 * of size product(shape...) will hold the full response.
-	 */
-	Shape []int   `msgpack:"shape"`
-	/*
-	 * The index, i.e. the ordered set of keys for each dimension. This is only
-	 * a (useful) suggestion for assembly, and data can be written in any
-	 * order.
-	 *
-	 * While assembly must be aware that bundles may show up in any order,
-	 * having a "map" (in the treasure map sense) of what shape and keys to
-	 * expect is quite useful for pre-allocation, and stuff like building a
-	 * language-specific index like in xarray in python.
-	 */
-	Index [][]int `msgpack:"index"`
-	/*
-	 * The attributes included in the request, such as cdpx, cdpy, cdpm etc.
-	 * Getting attributes is just another task, but this is a parsing hint for
-	 * the assembler.
-	 */
-	Attrs []string `msgpack:"attributes"`
-
 	RawHeader []byte
 }
 

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -206,13 +206,16 @@ struct tile {
     std::vector< float > v;
 };
 
-struct slice_tiles : public MsgPackable< slice_tiles > {
+struct slice_tiles {
     /*
      * The shape of the slice itself
      */
     std::string attr;
     std::vector< int > shape;
     std::vector< tile > tiles;
+
+    std::string pack()   const noexcept (false);
+    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
 struct single {

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -150,9 +150,9 @@ struct basic_task {
  * The contents and order of the shape and index depend on the request type and
  * parameters.
  */
-struct process_header : Packable< process_header > {
+struct process_header : MsgPackable< process_header > {
     std::string                         pid;
-    int                                 ntasks;
+    int                                 nbundles;
     std::vector< int >                  shape;
     std::vector< std::vector< int > >   index;
     std::vector< std::string >          attributes;

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -144,17 +144,27 @@ struct basic_task {
  * describes the number of tasks the process has been split into and advices
  * the client on how to parse the response.
  *
- * The process header is written from a point of awareness of the shape of the
- * survey, so the shape tuple is the shape of the response *with padding*.
+ * The index is context sensitive, and the content depends on the structure
+ * queried - for example, for a slice(dim: 0) it is the crossline numbers and
+ * time/depth interval.
  *
- * The contents and order of the shape and index depend on the request type and
- * parameters.
+ * The index is laid out linearly, fortran style, and the first ndims items are
+ * the dimensions. Conceptually it works like this:
+ *
+ * {
+ *  ndims: 2
+ *  index: [3 5 [n1 n2 n3] [m1 m2 m3 m4 m5]]
+ * }
+ *
+ * While it makes the structure slightly less intuitive, it makes parsing and
+ * serializing a lot simpler in many (otherwise clumsy) cases.
+ *
  */
 struct process_header : MsgPackable< process_header > {
     std::string                         pid;
     int                                 nbundles;
-    std::vector< int >                  shape;
-    std::vector< std::vector< int > >   index;
+    int                                 ndims;
+    std::vector< int >                  index;
     std::vector< std::string >          attributes;
 };
 

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -217,6 +217,14 @@ struct slice_tiles {
 struct single {
     /* id is a 3-tuple (i,j,k) that gives the fragment-ID */
     std::vector< int > id;
+
+    /*
+     * The offset is the index of this fragment in the lexicographically sorted
+     * set of fragments that make up a query. It is very useful for efficient
+     * extraction, and is just a mechanism for carrying the ordering of
+     * sub-tasks across boundaries, but carries no other semantics.
+     */
+    int offset;
     /*
      * coordinates is a 2-tuple (i', j') that gives the x/y position of the
      * trace. This is already a "local" coordinate a is 0-based.
@@ -229,13 +237,48 @@ struct curtain_task : public basic_task, Packable< curtain_task > {
     std::vector< single > ids;
 };
 
-struct trace {
-    std::vector< int > coordinates;
-    std::vector< float > v;
-};
+struct curtain_bundle {
+    /*
+     * This message describes correspond to traces all pulled from a single
+     * fragment [1], with a parallel-array layout.
+     *
+     * The curtain is an arbitrary collection of traces [(x1,y1), (x2,y2),
+     * ...], but every bundle of data holds only small pieces of the trace. An
+     * index is used to map segments onto the final result, but to reduce
+     * overhead it is compacted significantly.
+     *
+     * The index is composed of major and minor, and a simple algorithm to
+     * expand them; the majors serve as "keyframes", which correspond to
+     * (i,j,_) trace blocks in the lexicographically sorted request. The minors
+     * are "block-local" offsets. Put slightly differently - the major gives
+     * the fragment, the minors the trace segment *in* the fragment.
+     *
+     * Both the major and minor are laid out in [fst,lst) pairs; the length of
+     * either array is 2*size [2]. This is slightly redundant, but makes the
+     * structure much easier to use.
+     *
+     * The output is a 2-dimensional array with output-shape. In numpy syntax,
+     * extraction then becomes:
+     *
+     *    out[maj[i]:maj[i+1], min[i]:min[i+1]] = ...
+     *
+     * i.e. the major slices the 1st axis, the minor slices the 2nd axis.
+     *
+     * The parallel array layout is used because it fast and easy to pack and
+     * parse, and because it reduces the need for a dynamic and labelled
+     * structure. This is a detail that partially comes from using a statically
+     * typed language, but it makes for nice messages regardless.
+     *
+     * [1] conceptually, although multiple fragments may be merged
+     * [2] this might get changed to multiple shorter arrays
+     */
+    int size;
+    std::vector< int > major;
+    std::vector< int > minor;
+    std::vector< float > values;
 
-struct curtain_traces : public MsgPackable< curtain_traces > {
-    std::vector< trace > traces;
+    std::string pack() const noexcept (false);
+    void unpack(const char* fst, const char* lst) noexcept (false);
 };
 
 }

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -207,11 +207,7 @@ struct tile {
 };
 
 struct slice_tiles {
-    /*
-     * The shape of the slice itself
-     */
     std::string attr;
-    std::vector< int > shape;
     std::vector< tile > tiles;
 
     std::string pack()   const noexcept (false);

--- a/core/include/oneseismic/plan.hpp
+++ b/core/include/oneseismic/plan.hpp
@@ -9,11 +9,38 @@
 
 namespace one {
 
-std::string mkschedule(
-    const char* doc,
-    int len,
-    int task_size)
-noexcept (false);
+struct taskset {
+    std::vector< int >  sizes;
+    std::vector< char > packed;
+
+    bool empty() const noexcept (true) {
+        return this->sizes.empty();
+    }
+
+    std::size_t count() const noexcept (true) {
+        return this->sizes.size();
+    }
+
+    std::size_t size() const noexcept (true) {
+        return this->packed.size();
+    }
+
+    void reserve(int ntasks) {
+        // rough guess that all tasks are less or approx 12kb, to reduce the
+        // number of reallocs happening
+        constexpr const auto estimated_task_size = 12000;
+        this->sizes.reserve(ntasks);
+        this->packed.reserve(ntasks * estimated_task_size);
+    }
+
+    template < typename Seq >
+    void append(const Seq& task) noexcept (false) {
+        this->sizes.push_back(task.size());
+        this->packed.insert(this->packed.end(), task.begin(), task.end());
+    }
+};
+
+taskset mkschedule( const char* doc, int len, int task_size) noexcept (false);
 
 }
 

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -357,13 +357,11 @@ void from_json(const nlohmann::json& doc, tile& tile) noexcept (false) {
 
 void to_json(nlohmann::json& doc, const slice_tiles& tiles) noexcept (false) {
     doc["attribute"]  = tiles.attr;
-    doc["shape"]      = tiles.shape;
     doc["tiles"]      = tiles.tiles;
 }
 
 void from_json(const nlohmann::json& doc, slice_tiles& tiles) noexcept (false) {
     doc.at("attribute").get_to(tiles.attr);
-    doc.at("shape")    .get_to(tiles.shape);
     doc.at("tiles")    .get_to(tiles.tiles);
 }
 

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -160,7 +160,7 @@ void from_json(const nlohmann::json& doc, basic_task& task) noexcept (false) {
 void to_json(nlohmann::json& doc, const process_header& head) noexcept (false) {
     doc["pid"]          = head.pid;
     doc["nbundles"]     = head.nbundles;
-    doc["shape"]        = head.shape;
+    doc["ndims"]        = head.ndims;
     doc["index"]        = head.index;
     doc["attributes"]   = head.attributes;
 }
@@ -168,7 +168,7 @@ void to_json(nlohmann::json& doc, const process_header& head) noexcept (false) {
 void from_json(const nlohmann::json& doc, process_header& head) noexcept (false) {
     doc.at("pid")       .get_to(head.pid);
     doc.at("nbundles")  .get_to(head.nbundles);
-    doc.at("shape")     .get_to(head.shape);
+    doc.at("ndims")     .get_to(head.ndims);
     doc.at("index")     .get_to(head.index);
     doc.at("attributes").get_to(head.attributes);
 }

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -49,12 +49,12 @@ void MsgPackable< T >::unpack(const char* fst, const char* lst) noexcept (false)
  * interface, which would require go (and other dependencies) to be aware of
  * it.
  */
-template class Packable< process_header >;
 template class Packable< slice_query >;
 template class Packable< slice_task >;
 template class Packable< curtain_query >;
 template class Packable< curtain_task >;
 
+template class MsgPackable< process_header >;
 template class MsgPackable< slice_tiles >;
 template class MsgPackable< curtain_traces >;
 
@@ -159,7 +159,7 @@ void from_json(const nlohmann::json& doc, basic_task& task) noexcept (false) {
 
 void to_json(nlohmann::json& doc, const process_header& head) noexcept (false) {
     doc["pid"]          = head.pid;
-    doc["ntasks"]       = head.ntasks;
+    doc["nbundles"]     = head.nbundles;
     doc["shape"]        = head.shape;
     doc["index"]        = head.index;
     doc["attributes"]   = head.attributes;
@@ -167,7 +167,7 @@ void to_json(nlohmann::json& doc, const process_header& head) noexcept (false) {
 
 void from_json(const nlohmann::json& doc, process_header& head) noexcept (false) {
     doc.at("pid")       .get_to(head.pid);
-    doc.at("ntasks")    .get_to(head.ntasks);
+    doc.at("nbundles")  .get_to(head.nbundles);
     doc.at("shape")     .get_to(head.shape);
     doc.at("index")     .get_to(head.index);
     doc.at("attributes").get_to(head.attributes);

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -326,7 +326,7 @@ schedule_maker< slice_query, slice_task >::header(
 
     process_header head;
     head.pid        = query.pid;
-    head.ntasks     = ntasks;
+    head.nbundles   = ntasks;
     head.attributes = query.attributes;
 
     /*
@@ -479,7 +479,7 @@ schedule_maker< curtain_query, curtain_task >::header(
 
     process_header head;
     head.pid        = query.pid;
-    head.ntasks     = ntasks;
+    head.nbundles   = ntasks;
     head.attributes = query.attributes;
 
     const auto gvt  = geometry(query);

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -464,6 +464,7 @@ schedule_maker< curtain_query, curtain_task >::build(
             single top;
             top.id.assign(fid.begin(), fid.end());
             top.coordinates.reserve(approx_coordinates_per_fragment);
+            top.offset = i;
             itr = ids.insert(itr, zfrags, top);
             for (int z = 0; z < zfrags; ++z, ++itr)
                 itr->id[2] = z;
@@ -515,10 +516,6 @@ schedule_maker< curtain_query, curtain_task >::header(
     index.insert(index.end(), query.dim0s .begin(), query.dim0s .end());
     index.insert(index.end(), query.dim1s .begin(), query.dim1s .end());
     index.insert(index.end(), mdims.back().begin(), mdims.back().end());
-
-    auto itr = index.begin() + mdims.size();
-    itr = to_cartesian_inplace(mdims[0], itr, itr + query.dim0s.size());
-    itr = to_cartesian_inplace(mdims[1], itr, itr + query.dim1s.size());
 
     return head;
 }

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -132,9 +132,6 @@ void slice::init(const char* msg, int len) {
     this->layout = fragment_shape.slice_stride(this->dim);
     this->gvt = g3.squeeze(this->dim);
 
-    const auto& cs = this->gvt.cube_shape();
-    this->output.shape.assign(cs.begin(), cs.end());
-
     for (const auto& id : this->input.ids) {
         const auto name = fmt::format("{}", fmt::join(id, "-"));
         this->add_fragment(name, this->input.ext);

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -65,7 +65,7 @@ public:
 
 private:
     one::curtain_task   input;
-    one::curtain_traces output;
+    one::curtain_bundle output;
     one::gvt< 3 >       gvt;
     std::vector< int >  traceindex;
 };
@@ -175,6 +175,19 @@ void curtain::init(const char* msg, int len) {
         this->add_fragment(name, this->input.ext);
     }
 
+    const auto zsize = [this](const auto& id) noexcept {
+        /*
+         * Compute the size, in floats, of a block of (sub)traces. A block is
+         * made up of all the trace segments in one (i,j,k) fragment, and maybe
+         * padded.
+         */
+        const auto zdim     = this->gvt.mkdim(gvt.ndims - 1);
+        const auto zheight  = this->gvt.fragment_shape()[zdim];
+        const auto fid      = id3(id.id);
+        const auto zreal    = zheight - this->gvt.padding(fid, zdim);
+        return zreal * id.coordinates.size();
+    };
+
     /*
      * The curtain call uses an auxillary table to figure out where to write
      * traces as they are extracted from fragments. This simplifies the
@@ -197,7 +210,7 @@ void curtain::init(const char* msg, int len) {
         ids.begin(),
         ids.end(),
         this->traceindex.begin() + 1,
-        [](const auto& x) { return x.coordinates.size(); }
+        zsize
     );
     std::partial_sum(
         this->traceindex.begin(),
@@ -205,33 +218,46 @@ void curtain::init(const char* msg, int len) {
         this->traceindex.begin()
     );
 
-    const auto ntraces = this->traceindex.back();
-    this->output.traces.resize(ntraces);
+    const auto csize = [](const auto& x) noexcept {
+        return x.coordinates.size();
+    };
+
+    this->output.size = ids.size();
+    this->output.major.reserve(this->output.size * 2);
+    this->output.minor.reserve(this->output.size * 2);
+    this->output.values.resize(this->traceindex.back());
+    const auto zdim    = this->gvt.mkdim(gvt.ndims - 1);
+    const auto zheight = this->gvt.fragment_shape()[zdim];
+    const auto zmax    = this->gvt.nsamples(zdim);
+    for (const auto& id : ids) {
+        const auto zfst = id.id[zdim] * zheight;
+        const auto zlst = std::min(zfst + zheight, zmax);
+        this->output.major.push_back(id.offset);
+        this->output.major.push_back(id.offset + csize(id));
+        this->output.minor.push_back(zfst);
+        this->output.minor.push_back(zlst);
+    }
 }
 
 void curtain::add(int key, const char* chunk, int len) {
     const auto& id = this->input.ids[key];
-    assert(
-           this->traceindex[key] + int(id.coordinates.size())
-        == this->traceindex[key + 1]
-    );
 
-    const auto* fchunk = reinterpret_cast< const float* >(chunk);
-    auto out = this->output.traces.begin() + this->traceindex[key];
     const auto fid = id3(id.id);
-    const auto zheight = this->gvt.fragment_shape()[2];
+    const auto zdim    = this->gvt.mkdim(gvt.ndims - 1);
+    const auto zpad    = this->gvt.padding(fid, zdim);
+    const auto zheight = this->gvt.fragment_shape()[zdim] - zpad;
 
+    auto* dst = this->output.values.data() +  this->traceindex[key];
     for (const auto& coord : id.coordinates) {
         const auto fp = one::FP< 3 > {
             std::size_t(coord[0]),
             std::size_t(coord[1]),
             std::size_t(0),
         };
-        const auto global = this->gvt.to_global(fid, fp);
-        out->coordinates.assign(global.begin(), global.end());
         const auto off = this->gvt.fragment_shape().to_offset(fp);
-        out->v.assign(fchunk + off, fchunk + off + zheight);
-        ++out;
+        const auto src = chunk + off * sizeof(float);
+        std::memcpy(dst, src, sizeof(float) * zheight);
+        dst += zheight;
     }
 }
 

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -68,18 +68,25 @@ class assembler_slice(assembler):
 
         result = np.zeros(shape, dtype = np.single).ravel()
         for bundle in unpacked[1]:
-            if bundle.get('attribute') != 'data':
+            attribute = bundle[0]
+            tiles = bundle[1]
+
+            if attribute != 'data':
                 continue
-            for tile in bundle['tiles']:
-                layout = tile
-                dst = layout['initial-skip']
-                chunk_size = layout['chunk-size']
+
+            for tile in tiles:
+                iterations   = tile[0]
+                chunk_size   = tile[1]
+                initial_skip = tile[2]
+                superstride  = tile[3]
+                substride    = tile[4]
+                v            = tile[5]
                 src = 0
-                v = tile['v']
-                for _ in range(layout['iterations']):
+                dst = initial_skip
+                for _ in range(iterations):
                     result[dst : dst + chunk_size] = v[src : src + chunk_size]
-                    src += layout['substride']
-                    dst += layout['superstride']
+                    dst += superstride
+                    src += substride
 
         return result.reshape(shape)
 
@@ -104,20 +111,26 @@ class assembler_slice(assembler):
             attrs[attr] = np.zeros(np.prod(attrshape), dtype = dtype).ravel()
 
         for bundle in unpacked[1]:
-            if bundle['attribute'] not in attrs:
+            attribute = bundle[0]
+            tiles = bundle[1]
+
+            if attribute not in attrs:
                 continue
 
-            result = attrs[bundle['attribute']]
-            for tile in bundle['tiles']:
-                layout = tile
-                dst = layout['initial-skip']
-                chunk_size = layout['chunk-size']
+            result = attrs[attribute]
+            for tile in tiles:
+                iterations   = tile[0]
+                chunk_size   = tile[1]
+                initial_skip = tile[2]
+                superstride  = tile[3]
+                substride    = tile[4]
+                v            = tile[5]
                 src = 0
-                v = tile['v']
-                for _ in range(layout['iterations']):
+                dst = initial_skip
+                for _ in range(iterations):
                     result[dst : dst + chunk_size] = v[src : src + chunk_size]
-                    src += layout['substride']
-                    dst += layout['superstride']
+                    dst += superstride
+                    src += substride
 
         # TODO: add units for time/depth
         coords = {

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -62,11 +62,11 @@ class assembler_slice(assembler):
         self.name = name
 
     def numpy(self, unpacked):
-        index = unpacked[0]['index']
-        dims0 = len(index[0])
-        dims1 = len(index[1])
+        header = unpacked[0]
+        ndims = header['ndims']
+        shape = header['index'][:ndims]
 
-        result = np.zeros((dims0 * dims1), dtype = np.single)
+        result = np.zeros(shape, dtype = np.single).ravel()
         for bundle in unpacked[1]:
             if bundle.get('attribute') != 'data':
                 continue
@@ -81,25 +81,26 @@ class assembler_slice(assembler):
                     src += layout['substride']
                     dst += layout['superstride']
 
-        return result.reshape((dims0, dims1))
+        return result.reshape(shape)
 
     def xarray(self, unpacked):
-        index = unpacked[0]['index']
         a = self.numpy(unpacked)
-        shape = unpacked[0]['shape']
 
-        dims0 = len(index[0])
-        dims1 = len(index[1])
+        header = unpacked[0]
+        ndims = header['ndims']
+        index = header['index']
+        shape = index[:ndims]
 
         attrs = {}
         for attr in unpacked[0]['attributes']:
             dtype = 'f4'
             if self.name.startswith('time'):
                 attrlabels = self.dims
-                attrshape = [dims0, dims1]
+                attrshape = shape[:len(attrlabels)]
             else:
                 attrlabels = self.dims[0]
-                attrshape = [dims0]
+                attrshape = index[:len(attrlabels)]
+
             attrs[attr] = np.zeros(np.prod(attrshape), dtype = dtype).ravel()
 
         for bundle in unpacked[1]:
@@ -120,8 +121,8 @@ class assembler_slice(assembler):
 
         # TODO: add units for time/depth
         coords = {
-            self.dims[0]: index[0],
-            self.dims[1]: index[1],
+            self.dims[0]: index[ndims:][:shape[0]],
+            self.dims[1]: index[ndims:][shape[0]:]
         }
 
         for k, v in attrs.items():
@@ -134,6 +135,13 @@ class assembler_slice(assembler):
             coords = coords,
         )
 
+def splitindex(ndims, index):
+    shape = index[:ndims]
+    index = index[ndims:]
+    for k in shape:
+        yield index[:k]
+        index = index[k:]
+
 class assembler_curtain(assembler):
     kind = 'curtain'
 
@@ -142,10 +150,10 @@ class assembler_curtain(assembler):
         # server should be richer, to more easily allocate and construct a curtain
         # object
         header = unpacked[0]
-        shape = header['shape']
+        ndims = header['ndims']
         index = header['index']
-        dims0 = len(index[0])
-        dimsz = len(index[2])
+        shape = index[:ndims]
+        index = [dim for dim in splitindex(ndims, index)]
 
         # pre-compute where to put traces based on the dim0/dim1 coordinates
         # note that the index is made up of zero-indexed coordinates in the volume,
@@ -155,25 +163,32 @@ class assembler_curtain(assembler):
         # allocate the result. The shape can be slightly larger than dims0 * dimsz
         # since the traces can be padded at the end. By allocating space for the
         # padded traces we can just put floats directly into the array
-        xs = np.zeros(shape = shape, dtype = np.single)
+        xs = np.zeros(shape = shape[1:], dtype = np.single)
 
         for bundle in unpacked[1]:
             for part in bundle['traces']:
                 x, y, z = part['coordinates']
                 v = part['v']
-                xs[xyindex[(x, y)], z:z+len(v)] = v[:]
+                # the source may be longer than the target, since the source is
+                # padded. Numpy doesn't automatically truncate if the
+                # right-hand-side of the assignment is larger than the left, so
+                # manually truncate the source at the padding boundary
+                dst = xs[xyindex[(x, y)], z:z+len(v)]
+                dst[:] = v[:dst.shape[-1]]
 
-        return xs[:dims0, :dimsz]
+        return xs
 
     def xarray(self, unpacked):
-        index = unpacked[0]['index']
         a = self.numpy(unpacked)
         ijk = self.sourcecube.ijk
 
+        header = unpacked[0]
+        index = header['index']
+        ndims = header['ndims']
+        index = [dim for dim in splitindex(ndims, index)]
+
         xs = [ijk[0][x] for x in index[0]]
         ys = [ijk[1][x] for x in index[1]]
-        # TODO: address this inconsistency - zs is in 'real' sample offsets,
-        # while xs/ys are cube indexed
         zs = index[2]
         da = xarray.DataArray(
             data = a,

--- a/python/oneseismic/upload/upload.py
+++ b/python/oneseismic/upload/upload.py
@@ -238,7 +238,7 @@ class cdpset(fileset):
             'type': f'cdp{self.type}',
             'layout': 'tiled',
             'file-extension': self.ext,
-            'labels': [f'cdp self.type}'.upper()],
+            'labels': [f'cdp {self.type}'.upper()],
             'shapes': [self.shape],
             'prefix': self.prefix,
         },


### PR DESCRIPTION
This PR comes with some performance improvements and hygiene stuff, but the big feature is *drastically* reducing the response message size for slices by using tuples over maps.

The message layout used until now had good library support and was quick and easy to get started with (nlohmann/json msgpack serialization), but made for terrible messages in system <-> system communication. This PR demonstrates the benefit of packing messages more deliberately, but is still not very bold, as it's not hooking into the msgpack ext-type system.

The patch provides strong value on its own, but is a step towards a streaming and C++-provided user-side message parsing.

---

Pack the slice response, tiles, as a sequence of tuples rather than a
sequence of maps. By using tuples the message size is dramatically
reduced. I measured slices from a 500M cube in all dimensions [1]:

|             | dim 0 | dim 1 | dim 2 |
|-------------|-------|-------|-------|
| array size  | 2.45M | 0.68M | 0.58M |
| old payload | 6.21M | 2.07M | 1.78M |
| new payload | 3.45M | 1.15  | 0.99M |

This saves 40-50% on message size, which translates to less network
pressure and faster parsing. This comes with little code complexity, but
messages are less self-descriptive and rely on a shared understanding of
the schema (which was always the case anyway).

[1] New also includes the flattened index, but that should reduce by an
    additional 5-8 bytes or so