### PR TITLE
Add decoder

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-2016]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,6 +42,8 @@ jobs:
             cmake -S core/ -B build/
             -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
             -DVCPKG_TARGET_TRIPLET=x64-windows
+            -G "Visual Studio 15 2017"
+            -A x64
 
       - name: Configure
         run: >
@@ -59,6 +61,26 @@ jobs:
 
       - name: Install python dependencies
         run: python -m pip install -r python/requirements-dev.txt
+
+      - name: Build python module
+        if: startsWith(matrix.os, 'windows')
+        working-directory: python
+        run: >
+            python setup.py
+            build_ext --inplace build
+            --
+            -Doneseismic_DIR="${{ github.workspace }}/build"
+            -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
+            -DVCPKG_TARGET_TRIPLET=x64-windows
+
+      - name: Build python module
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        working-directory: python
+        run: >
+            python setup.py
+            build_ext --inplace build
+            --
+            -Doneseismic_DIR="${{ github.workspace }}/build"
 
       - name: Run python tests
         working-directory: python

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,0 +1,38 @@
+name: Wheels
+
+on: [push, pull_request]
+
+jobs:
+  wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macOS-10.15]
+        include:
+          - os: windows-2016
+            cibw-arch: AMD64
+            cmake-generator: "Visual Studio 15 2017 Win64"
+          - os: windows-2016
+            cibw-arch: x86
+            cmake-generator: "Visual Studio 15 2017"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel
+
+      - name: Build wheels
+        env:
+          CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="${{ matrix.cmake-generator }}"
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw-arch }}
+        run: |
+            python -m cibuildwheel --output-dir wheelhouse python/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=OFF \
     -DBUILD_TESTING=OFF \
-    -DBUILD_PYTHON=OFF \
     -DCMAKE_CXX_FLAGS=-DFMT_HEADER_ONLY=1 \
     -DCMAKE_INSTALL_PREFIX=/usr/local \
     /src/core

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.12)
 project(oneseismic LANGUAGES CXX)
 
 include(CheckIncludeFile)
@@ -6,12 +6,12 @@ include(CTest)
 include(GNUInstallDirs)
 include(TestBigEndian)
 
-option(BUILD_PYTHON  "Build Python library"                ON)
+option(BUILD_CORE      "Build the core library"      ON)
+option(BUILD_DECODER   "Build the decoder library"   ON)
 
-add_library(json INTERFACE)
-target_include_directories(json INTERFACE external/nlohmann)
-
-find_package(fmt        REQUIRED)
+if (BUILD_TESTING)
+    add_subdirectory(external/catch2)
+endif ()
 
 if (NOT MSVC)
     # assuming gcc-style options
@@ -32,26 +32,61 @@ endif ()
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_library(oneseismic
-    src/base64.cpp
-    src/messages.cpp
-    src/plan.cpp
-    src/process.cpp
-    src/decoder.cpp
-)
+add_library(oneseismic)
 add_library(oneseismic::oneseismic ALIAS oneseismic)
 target_include_directories(oneseismic
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
-    PRIVATE
-        include
-        external/nlohmann
 )
-target_link_libraries(oneseismic
-    PUBLIC
-        fmt::fmt
-)
+
+# Some users will not want the full library (e.g. language bindings for the
+# decoder), so the sources and dependencies are guarded behind feature
+# toggles.
+if (BUILD_CORE)
+    add_library(json INTERFACE)
+    target_include_directories(json INTERFACE external/nlohmann)
+    find_package(fmt REQUIRED)
+
+    target_sources(oneseismic
+        PRIVATE
+            src/base64.cpp
+            src/messages.cpp
+            src/plan.cpp
+            src/process.cpp
+    )
+
+    target_include_directories(oneseismic
+        PRIVATE
+            include
+            external/nlohmann
+    )
+    target_link_libraries(oneseismic
+        PUBLIC
+            fmt::fmt
+    )
+
+    if (BUILD_TESTING)
+        add_executable(core-tests
+            tests/testsuite.cpp
+            tests/geometry.cpp
+            tests/messages.cpp
+            tests/process.cpp
+        )
+        target_link_libraries(core-tests
+            PRIVATE
+                catch2
+                oneseismic::oneseismic
+                fmt::fmt
+                json
+        )
+        add_test(NAME unit-tests COMMAND core-tests)
+    endif ()
+endif ()
+
+if (BUILD_DECODER)
+    target_sources(oneseismic PRIVATE src/decoder.cpp)
+endif ()
 
 install(
     TARGETS
@@ -84,25 +119,3 @@ export(
     NAMESPACE
         oneseismic::
 )
-set(ONESEISMIC_LIB_CMAKECONFIG_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "")
-
-if (NOT BUILD_TESTING)
-    return()
-endif ()
-
-add_subdirectory(external/catch2)
-
-add_executable(tests
-    tests/testsuite.cpp
-    tests/geometry.cpp
-    tests/messages.cpp
-    tests/process.cpp
-)
-target_link_libraries(tests
-    PRIVATE
-        catch2
-        oneseismic::oneseismic
-        fmt::fmt
-        json
-)
-add_test(NAME unit-tests COMMAND tests)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(oneseismic
     src/messages.cpp
     src/plan.cpp
     src/process.cpp
+    src/decoder.cpp
 )
 add_library(oneseismic::oneseismic ALIAS oneseismic)
 target_include_directories(oneseismic

--- a/core/include/oneseismic/decoder.hpp
+++ b/core/include/oneseismic/decoder.hpp
@@ -8,6 +8,7 @@
 
 #include <oneseismic/messages.hpp>
 
+
 namespace one {
 
 /*

--- a/core/include/oneseismic/decoder.hpp
+++ b/core/include/oneseismic/decoder.hpp
@@ -1,0 +1,163 @@
+#ifndef ONESEISMIC_DECODER_HPP
+#define ONESEISMIC_DECODER_HPP
+
+#include <map>
+#include <string>
+
+#include <msgpack.hpp>
+
+#include <oneseismic/messages.hpp>
+
+namespace one {
+
+/*
+ * Class to parse the response message format, and extract into the intended
+ * "target" structure. The main feature is the streaming support; it is built
+ * for working on not-yet-complete messages, and wired directly to the download
+ * stream.
+ */
+class decoder {
+public:
+    enum class status {
+        paused,
+        done,
+    };
+
+    /*
+     * Buffer up some data, but don't process it yet. Calling this over
+     * buffer_and_process can be useful if you want to free up your own
+     * buffers, but not yet start processing (e.g. when you know that it's just
+     * half an object anyway), or if you want to delay processing until all
+     * data is read.
+     */
+    void buffer(const char* input, std::size_t len);
+
+    /*
+     * Process as many message parts as possible.
+     *
+     * This function does nothing if:
+     * * no data is buffered
+     * * no complete message is buffered
+     * * the message completely processed
+     *
+     * The function will *always* pause once it parses the header, and in order
+     * to parse a full message it must be called *at least* twice. It stops
+     * because writers for the message must be registered, and registering them
+     * requires data that is in the header.
+     *
+     * Process will throw an exception if the internal state machine breaks, or
+     * the message is corrupted and cannot be processed further, which means
+     * process() can be called repeatedly until it returns done.
+     *
+     * Example
+     * -------
+     * while (true) {
+     *     stream.read();
+     *     a.buffer(stream.bytes, stream.len);
+     *     a.process();
+     *
+     *     if (a.header()) {
+     *         for (auto& attr : a.header()->attributes) {
+     *             auto* wr = outputs.alloc(attr);
+     *             a.register_writer(attr, wr);
+     *         }
+     *         break;
+     *     }
+     * }
+     *
+     * while (true) {
+     *     stream.read()
+     *     a.buffer(stream.bytes, stream.len);
+     *     status = a.process();
+     *     if (status == done)
+     *         break;
+     * }
+     */
+    status process();
+
+    /*
+     * Call buffer and process in sequence. This is usually the function you
+     * want to use. This function can be called until it returns status::done.
+     */
+    status buffer_and_process(const char* input, std::size_t len);
+
+    /*
+     * Get the process header for the current request, if available. This
+     * function returns nullptr if the header has not been processed yet, in
+     * which case callers must buffer and process more data. The pointer is
+     * valid until the next call to reset(), or until this object is destroyed.
+     */
+    const process_header* header() const noexcept (true);
+
+    /*
+     * If you are re-using the decoder between messages, call reset() before
+     * starting a new message.
+     */
+    void reset();
+
+    /*
+     * Register a writer/output arena for some attribute. *data should be a
+     * buffer large enough for the output.
+     *
+     * Examples
+     * --------
+     * Pre-allocate a numpy array and register it as the writer. This is for a
+     * slice, and the allocation must be aware of the shape of the output based
+     * on the shape+index.
+     *
+     * head = a.header()
+     * arrays = {}
+     * for attr in head.attributes:
+     *     shape = head.index[:head.ndims]
+     *     npa = np.zeros(shape = shape, dtype = 'f4')
+     *     a.register_writer(attr, npa)
+     *     arrays[attr] = npa
+     * # process-all
+     */
+    void register_writer(const std::string& attr, void* data);
+
+private:
+    msgpack::v2::unpacker unp;
+    msgpack::v2::object_handle objhandle;
+
+    /*
+     * Processing functions
+     *
+     * These process and extract the parsed message components into the right
+     * output structure. If you are implementing response message parsing
+     * outside of the decoder, then you  can extract the algorithms from the
+     * processing functions. They are kept private until exposing them is
+     * actually necessary and useful, in order to make it easier to evolve the
+     * messages, and keep the public API smaller.
+     */
+    void extract(const msgpack::v2::object&) noexcept (false);
+    void slice  (const msgpack::v2::object&) noexcept (false);
+    void curtain(const msgpack::v2::object&) noexcept (false);
+
+    /*
+     * Look for the writer for some attribute ('data', 'cdpx' etc.). If no such
+     * writer is registered, this returns nullptr indicating that the block can
+     * be skipped.
+     *
+     * Not registering a writer is not an error, it is choosing to ignore parts
+     * of the response.
+     */
+    char* get_writer_for(const std::string& attr) noexcept (true);
+
+    enum class state {
+        envelope,
+        header,
+        nbundles,
+        bundles,
+        done,
+    };
+
+    state phase = state::envelope;
+    int nbundles = 0;
+    process_header head;
+    std::map< std::string, void* > writers;
+};
+
+}
+
+#endif //ONESEISMIC_DECODER_HPP

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -160,8 +160,15 @@ struct basic_task {
  * serializing a lot simpler in many (otherwise clumsy) cases.
  *
  */
+
+enum class functionid {
+    slice   = 1,
+    curtain = 2,
+};
+
 struct process_header : MsgPackable< process_header > {
     std::string                         pid;
+    functionid                          function;
     int                                 nbundles;
     int                                 ndims;
     std::vector< int >                  index;

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -279,6 +279,7 @@ struct curtain_bundle {
      * [1] conceptually, although multiple fragments may be merged
      * [2] this might get changed to multiple shorter arrays
      */
+    std::string attr;
     int size;
     std::vector< int > major;
     std::vector< int > minor;

--- a/core/src/decoder.cpp
+++ b/core/src/decoder.cpp
@@ -1,0 +1,399 @@
+#include <vector>
+#include <string>
+#include <map>
+#include <exception>
+
+#include <msgpack.hpp>
+
+#include <oneseismic/decoder.hpp>
+#include <oneseismic/messages.hpp>
+
+namespace msgpack {
+namespace v2 {
+namespace adaptor {
+
+template <>
+struct convert< one::functionid > {
+    const v2::object& operator () (const v2::object& o, one::functionid& id)
+    const noexcept (false) {
+        const auto v = o.as< int >();
+        switch (static_cast< one::functionid >(v)) {
+            case one::functionid::slice:
+            case one::functionid::curtain:
+                break;
+
+            default: {
+                const auto msg = "Invalid function; was " + std::to_string(v);
+                throw one::bad_value(msg);
+            }
+        }
+
+        id = static_cast< one::functionid >(v);
+        return o;
+    }
+};
+
+template <>
+struct convert< one::process_header > {
+    const v2::object& operator () (const v2::object& o, one::process_header& head)
+    const noexcept (false) {
+        if (o.type != type::MAP)
+            throw type_error();
+
+        const auto& kvs = o.via.map;
+        std::string key;
+        for (int i = 0; i < kvs.size; ++i) {
+            const auto& kv = kvs.ptr[i];
+            kv.key >> key;
+                 if (key == "pid")        kv.val >> head.pid;
+            else if (key == "function")   kv.val >> head.function;
+            else if (key == "nbundles")   kv.val >> head.nbundles;
+            else if (key == "ndims")      kv.val >> head.ndims;
+            else if (key == "index")      kv.val >> head.index;
+            else if (key == "attributes") kv.val >> head.attributes;
+            else {
+                throw one::bad_message("Unknown key '" + key + "' in header");
+            }
+        }
+        return o;
+    }
+};
+
+}}}
+
+namespace one {
+
+namespace {
+
+[[nodiscard]]
+auto asarray(const msgpack::v2::object& obj)
+noexcept (false)
+-> decltype(obj.via.array)
+{
+    if (obj.type == msgpack::v2::type::ARRAY)
+        return obj.via.array;
+
+    throw msgpack::v2::type_error();
+}
+
+[[nodiscard]]
+auto astuple(const msgpack::v2::object& obj, int len)
+noexcept (false)
+-> decltype(obj.via.array.ptr)
+{
+    const auto a = asarray(obj);
+    if (a.size != len) {
+        const auto msg = "expected " + std::to_string(len)
+                       + " slots, was "
+                       + std::to_string(a.size)
+                       ;
+        throw bad_message(msg);
+    }
+
+    return a.ptr;
+}
+
+[[nodiscard]]
+auto asbinarray(const msgpack::v2::object& obj)
+noexcept (false)
+-> decltype(obj.via.bin)
+{
+    if (obj.type == msgpack::v2::type::BIN)
+        return obj.via.bin;
+
+    throw msgpack::v2::type_error();
+}
+
+std::uint32_t net32(const char* net) noexcept (true) {
+    std::uint8_t data[sizeof(std::uint32_t)] = {};
+    std::memcpy(&data, net, sizeof(data));
+    return ((std::uint32_t) data[3] << 0)
+         | ((std::uint32_t) data[2] << 8)
+         | ((std::uint32_t) data[1] << 16)
+         | ((std::uint32_t) data[0] << 24)
+    ;
+}
+
+std::uint16_t net16(const char* net) noexcept (true) {
+    std::uint8_t data[sizeof(std::uint16_t)] = {};
+    std::memcpy(&data, net, sizeof(data));
+    return ((std::uint16_t) data[1] << 8)
+         | ((std::uint16_t) data[0] << 0)
+    ;
+}
+
+struct insufficient_bytes : public std::exception {};
+int parse_array_len(const char* input, std::size_t size, int& len)
+noexcept (false) {
+    if (size < 1) throw insufficient_bytes();
+    const auto tag = std::uint8_t(input[0]);
+
+    if ((tag & 0xF0) == 0x90) {
+        len = tag & 0x0F;
+        return 1;
+    }
+    else if (tag == 0xDC) {
+        if (size < 3) throw insufficient_bytes();
+        len = net16(input + 1);
+        return sizeof(std::uint16_t) + 1;
+    }
+    else if (tag == 0xDD) {
+        if (size < 5) throw insufficient_bytes();
+        len = net32(input + 1);
+        return sizeof(std::uint32_t) + 1;
+    } else {
+        const auto msg = "expected array tag; was " + std::to_string(int(tag));
+        throw bad_message(msg);
+    }
+}
+
+int unpack_array_len(msgpack::v2::unpacker& unp) {
+    int len;
+    const auto* unparsed = unp.nonparsed_buffer();
+    const auto remaining = unp.nonparsed_size();
+    const auto nread = parse_array_len(unparsed, remaining, len);
+    unp.skip_nonparsed_buffer(nread);
+    return len;
+}
+
+void read_check_envelope(msgpack::v2::unpacker& unp) noexcept (false) {
+    const auto len = unpack_array_len(unp);
+    if (len == 2)
+        return;
+
+    const auto msg = "bad envelope; expected array(2), was ";
+    throw bad_message(msg + std::to_string(len));
+}
+
+}
+
+void decoder::reset() {
+    // TODO: soft reset where phase, nbundles are reset, but the buffer and
+    // optionally writers are not?
+    this->unp.remove_nonparsed_buffer();
+    this->phase = state::envelope;
+    this->nbundles = 0;
+    this->writers.clear();
+}
+
+const process_header* decoder::header() const noexcept (true) {
+    switch (this->phase) {
+        case state::envelope:
+        case state::header:
+            return nullptr;
+
+        default:
+            return &this->head;
+    }
+}
+
+void decoder::register_writer(const std::string& attr, void* data) {
+    this->writers[attr] = data;
+}
+
+void decoder::buffer(const char* input, std::size_t size) {
+    if (size > 0) {
+        this->unp.reserve_buffer(size);
+        std::copy_n(input, size, this->unp.buffer());
+        this->unp.buffer_consumed(size);
+    }
+}
+
+/*
+ * process() implements a fairly simple state machine that parses and processes
+ * the response message, and is aware that the message may be incomplete. This
+ * is a rough overview of the message structure:
+ *
+ * [0] envelope
+ * [1] header
+ * [2] nbundles
+ * [3] bundles*
+ *
+ * The message format is built on top of msgpack, and all messages are complete
+ * and valid msgpack messages. The goal for this function is to *stream* the
+ * data, which means extracting the individual values as they are parsed,
+ * rather than parsing into an intermediary msgpack structure, and then
+ * performing extraction on the result of the parsing.
+ *
+ * The message is packaged as an array of 3 elements:
+ *  - The [1] header
+ *  - The [2] nbundles
+ *  - The [3] bundles
+ *
+ * This makes the envelope simply the array-type + length (2). The header [1]
+ * is the process_header in messages.hpp. The nbundles [2] tells the
+ * parse-and-extract how many bundles the payload is made up of (which should
+ * correspond to the nbundles field in the process header), and is just the
+ * array type + length. Finally, the bundles is the n blobs that make up the
+ * response body.
+ *
+ * The process() function will *always* give back control after parsing the
+ * header, even if a full message is buffered. Since extraction is done by
+ * looking up writers which must be registered on a per-message basis, it is
+ * vital that no payload is touched before the caller has had the oportunity to
+ * register writers, but the caller cannot know what writers to register
+ * without reading the header.
+ */
+decoder::status decoder::process() {
+    switch (this->phase) {
+        case state::envelope: {
+            try {
+                read_check_envelope(this->unp);
+            } catch (insufficient_bytes&) {
+                return status::paused;
+            }
+            this->phase = state::header;
+        }
+        /* INTENTIONAL FALL-THROUGH */
+
+        case state::header:
+            if (!this->unp.next(this->objhandle))
+                return status::paused;
+
+            this->objhandle.get() >> this->head;
+            this->phase = state::nbundles;
+            return status::paused;
+
+        case state::nbundles: {
+            try {
+                this->nbundles = unpack_array_len(this->unp);
+            } catch (insufficient_bytes&) {
+                return status::paused;
+            }
+            if (nbundles != this->head.nbundles) {
+                const auto msg = "nbundles inconsistent; header.nbundles = "
+                    + std::to_string(this->head.nbundles)
+                    + ", envelope.nbundles = "
+                    + std::to_string(nbundles)
+                ;
+                throw bad_message(msg);
+            }
+            this->phase = state::bundles;
+        }
+        /* INTENTIONAL FALL-THROUGH */
+
+        case state::bundles:
+            while (this->nbundles > 0) {
+                if (!this->unp.next(this->objhandle))
+                    return status::paused;
+
+                this->extract(this->objhandle.get());
+                this->nbundles -= 1;
+            }
+            this->phase = state::done;
+            return status::done;
+
+        case state::done:
+            return status::done;
+
+        default:
+            throw std::logic_error("void phase; should be unreachable");
+    }
+}
+
+decoder::status decoder::buffer_and_process(
+    const char* input,
+    std::size_t size)
+{
+    this->buffer(input, size);
+    return this->process();
+}
+
+void decoder::extract(const msgpack::v2::object& obj) {
+    switch (this->head.function) {
+        case functionid::slice:
+            this->slice(obj);
+            return;
+
+        case functionid::curtain:
+            this->curtain(obj);
+            return;
+
+        default:
+            break;
+    }
+
+    const auto msg = "void function; message poorly sanitized";
+    throw std::logic_error(msg);
+}
+
+void decoder::slice(const msgpack::v2::object& obj)
+noexcept (false) {
+    const auto root = astuple(obj, 2);
+
+    const auto attribute = root[0].as< std::string >();
+    auto* dst = this->get_writer_for(attribute);
+    if (!dst)
+        return;
+
+    const auto atiles = asarray(root[1]);
+    const auto ntiles = atiles.size;
+    const auto tiles  = atiles.ptr;
+
+    for (int i = 0; i < ntiles; ++i) {
+        const auto slots = astuple(tiles[i], 6);
+
+        const auto iterations   = slots[0].as< int >();
+        const auto chunk_size   = slots[1].as< int >();
+        const auto initial_skip = slots[2].as< int >();
+        const auto superstride  = slots[3].as< int >();
+        const auto substride    = slots[4].as< int >();
+        const auto v            = asbinarray(slots[5]);
+
+        const auto* src = v.ptr;
+        for (int i = 0; i < iterations; ++i) {
+            std::memcpy(
+                dst + sizeof(float) * (i * superstride + initial_skip),
+                src + sizeof(float) * (i * substride),
+                sizeof(float) * chunk_size
+            );
+        }
+    }
+}
+
+void decoder::curtain(const msgpack::v2::object& obj)
+noexcept (false) {
+    const auto& slots = astuple(obj, 5);
+
+    const auto attribute = slots[0].as< std::string >();
+    auto* dst = this->get_writer_for(attribute);
+    if (!dst)
+        return;
+
+    // TODO: check message integrity (array sizes)
+    // TODO: cache vectors
+    const auto size  = slots[1].as< int >();
+    const auto major = slots[2].as< std::vector< int > >();
+    const auto minor = slots[3].as< std::vector< int > >();
+    const auto v     = asbinarray(slots[4]);
+
+    const auto* src = v.ptr;
+    const auto zlen = this->head.index[2];
+    for (int n = 0; n < size; ++n) {
+        const auto ifst = major[n*2 + 0];
+        const auto ilst = major[n*2 + 1];
+        const auto zfst = minor[n*2 + 0];
+        const auto zlst = minor[n*2 + 1];
+
+        const auto elemsize = sizeof(float);
+        const auto chunksize = elemsize * (zlst - zfst);
+        for (int i = ifst; i < ilst; ++i) {
+            const auto chunk = i - ifst;
+            std::memcpy(
+                dst + elemsize  * (i*zlen + zfst),
+                src + chunksize * chunk,
+                chunksize
+            );
+        }
+        src += chunksize * (ilst - ifst);
+    }
+}
+
+char* decoder::get_writer_for(const std::string& attr) noexcept (true) {
+    auto itr = this->writers.find(attr);
+    if (itr == this->writers.end())
+        return nullptr;
+    return reinterpret_cast< char* >(itr->second);
+}
+
+}

--- a/core/src/decoder.cpp
+++ b/core/src/decoder.cpp
@@ -65,7 +65,6 @@ namespace one {
 
 namespace {
 
-[[nodiscard]]
 auto asarray(const msgpack::v2::object& obj)
 noexcept (false)
 -> decltype(obj.via.array)
@@ -76,7 +75,6 @@ noexcept (false)
     throw msgpack::v2::type_error();
 }
 
-[[nodiscard]]
 auto astuple(const msgpack::v2::object& obj, int len)
 noexcept (false)
 -> decltype(obj.via.array.ptr)
@@ -93,7 +91,6 @@ noexcept (false)
     return a.ptr;
 }
 
-[[nodiscard]]
 auto asbinarray(const msgpack::v2::object& obj)
 noexcept (false)
 -> decltype(obj.via.bin)

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -114,7 +114,8 @@ std::string curtain_bundle::pack() const noexcept (false) {
     msgpack::sbuffer buffer;
     msgpack::packer< decltype(buffer) > packer(buffer);
 
-    packer.pack_array(4);
+    packer.pack_array(5);
+    packer.pack(this->attr);
     packer.pack(size);
     packer.pack(major);
     packer.pack(minor);
@@ -128,13 +129,14 @@ noexcept (false) {
     const auto& obj = result.get();
     ensurearray(obj);
 
-    if (obj.via.array.size < 4)
-        throw bad_message("expected array of len 4");
+    if (obj.via.array.size < 5)
+        throw bad_message("expected array of len 5");
 
-    obj.via.array.ptr[0] >> this->size;
-    obj.via.array.ptr[1] >> this->major;
-    obj.via.array.ptr[2] >> this->minor;
-    obj.via.array.ptr[3] >> this->values;
+    obj.via.array.ptr[0] >> this->attr;
+    obj.via.array.ptr[1] >> this->size;
+    obj.via.array.ptr[2] >> this->major;
+    obj.via.array.ptr[3] >> this->minor;
+    obj.via.array.ptr[4] >> this->values;
 }
 
 

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -239,6 +239,7 @@ void from_json(const nlohmann::json& doc, basic_task& task) noexcept (false) {
 
 void to_json(nlohmann::json& doc, const process_header& head) noexcept (false) {
     doc["pid"]          = head.pid;
+    doc["function"]     = head.function;
     doc["nbundles"]     = head.nbundles;
     doc["ndims"]        = head.ndims;
     doc["index"]        = head.index;
@@ -247,6 +248,7 @@ void to_json(nlohmann::json& doc, const process_header& head) noexcept (false) {
 
 void from_json(const nlohmann::json& doc, process_header& head) noexcept (false) {
     doc.at("pid")       .get_to(head.pid);
+    doc.at("function")  .get_to(head.function);
     doc.at("nbundles")  .get_to(head.nbundles);
     doc.at("ndims")     .get_to(head.ndims);
     doc.at("index")     .get_to(head.index);

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -42,6 +42,19 @@ void MsgPackable< T >::unpack(const char* fst, const char* lst) noexcept (false)
     self = nlohmann::json::from_msgpack(fst, lst).get< T >();
 }
 
+namespace {
+
+template < typename Packer, typename T >
+void packarray_bin(Packer& packer, const std::vector< T >& vec)
+noexcept (true) {
+    const auto vsize = vec.size() * sizeof(T);
+    const auto* body = reinterpret_cast< const char* >(vec.data());
+    packer.pack_bin(vsize);
+    packer.pack_bin_body(body, vsize);
+}
+
+}
+
 std::string slice_tiles::pack() const noexcept (false) {
     msgpack::sbuffer buffer;
     msgpack::packer< decltype(buffer) > packer(buffer);
@@ -66,7 +79,7 @@ std::string slice_tiles::pack() const noexcept (false) {
         packer.pack(tile.initial_skip);
         packer.pack(tile.superstride);
         packer.pack(tile.substride);
-        packer.pack(tile.v);
+        packarray_bin(packer, tile.v);
     }
 
     return std::string(buffer.data(), buffer.size());
@@ -105,7 +118,12 @@ void slice_tiles::unpack(const char* fst, const char* lst) noexcept (false) {
         t.initial_skip  = ptile[2].as< int >();
         t.superstride   = ptile[3].as< int >();
         t.substride     = ptile[4].as< int >();
-        t.v             = ptile[5].as< std::vector< float > >();
+
+        if (ptile[5].type != msgpack::v2::type::BIN)
+            throw bad_value("tile.v should be BIN");
+        auto tv = ptile[5].via.bin;
+        t.v.resize(tv.size / sizeof(float));
+        std::memcpy(t.v.data(), tv.ptr, tv.size);
         this->tiles.push_back(std::move(t));
     }
 }
@@ -119,7 +137,7 @@ std::string curtain_bundle::pack() const noexcept (false) {
     packer.pack(size);
     packer.pack(major);
     packer.pack(minor);
-    packer.pack(values);
+    packarray_bin(packer, this->values);
     return std::string(buffer.data(), buffer.size());
 }
 
@@ -136,7 +154,12 @@ noexcept (false) {
     obj.via.array.ptr[1] >> this->size;
     obj.via.array.ptr[2] >> this->major;
     obj.via.array.ptr[3] >> this->minor;
-    obj.via.array.ptr[4] >> this->values;
+
+    auto tv = obj.via.array.ptr[4];
+    if (tv.type != msgpack::v2::type::BIN)
+        throw bad_value("curtain.values should be BIN");
+    this->values.resize(tv.via.bin.size / sizeof(float));
+    std::memcpy(this->values.data(), tv.via.bin.ptr, tv.via.bin.size);
 }
 
 

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -344,6 +344,7 @@ schedule_maker< slice_query, slice_task >::header(
 
     process_header head;
     head.pid        = query.pid;
+    head.function   = functionid::slice;
     head.nbundles   = ntasks;
     head.ndims      = mdims.size() - 1;
     head.attributes = query.attributes;
@@ -499,6 +500,7 @@ schedule_maker< curtain_query, curtain_task >::header(
 
     process_header head;
     head.pid        = query.pid;
+    head.function   = functionid::curtain;
     head.nbundles   = ntasks;
     head.ndims      = mdims.size();
     head.attributes = query.attributes;

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -223,6 +223,7 @@ void curtain::init(const char* msg, int len) {
         return x.coordinates.size();
     };
 
+    this->output.attr = this->input.attribute;
     this->output.size = ids.size();
     this->output.major.reserve(this->output.size * 2);
     this->output.minor.reserve(this->output.size * 2);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.13)
+project(oneseismic-python LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+set(CMAKE_C_VISIBILITY_PRESET   "hidden")
+
+if (SKBUILD)
+  # scikit-build does not add your site-packages to the search path automatically,
+  # so we need to add it _or_ the pybind11 specific directory here.
+  execute_process(
+    COMMAND
+      "${PYTHON_EXECUTABLE}" -c
+      "import pybind11; print(pybind11.get_cmake_dir())"
+    OUTPUT_VARIABLE _tmp_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
+endif()
+
+find_package(PythonExtensions REQUIRED)
+find_package(pybind11 REQUIRED)
+find_package(oneseismic REQUIRED)
+
+# fmt is not required - oneseismic supports building a slim core (only the
+# decoder), which makes it easier to build for python. dev-builds usually link
+# against the full package however, which has more dependencies, so looking and
+# accepting missing packages is a good balance between use cases
+find_package(fmt)
+
+add_library(decoder MODULE oneseismic/decoder.cpp)
+python_extension_module(decoder)
+target_link_libraries(decoder
+    pybind11::headers
+    oneseismic::oneseismic
+)
+
+install(
+    TARGETS decoder
+    LIBRARY DESTINATION oneseismic
+    RUNTIME DESTINATION oneseismic
+)

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -122,7 +122,7 @@ class assembler:
                 attrshape = shape[:len(attrlabels)]
             else:
                 attrlabels = self.dims[0]
-                attrshape = index[:len(attrlabels)]
+                attrshape = shape[0]
 
             attrs[attr] = np.zeros(np.prod(attrshape), dtype = dtype).ravel()
 

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -97,6 +97,7 @@ class assembler:
                 superstride  = tile[3]
                 substride    = tile[4]
                 v            = tile[5]
+                v = np.frombuffer(v, dtype = 'f4')
                 src = 0
                 dst = initial_skip
                 for _ in range(iterations):
@@ -141,6 +142,7 @@ class assembler:
                 superstride  = tile[3]
                 substride    = tile[4]
                 v            = tile[5]
+                v = np.frombuffer(v, dtype = 'f4')
                 src = 0
                 dst = initial_skip
                 for _ in range(iterations):
@@ -184,7 +186,7 @@ class assembler:
             major   = bundle[2]
             minor   = bundle[3]
             values  = bundle[4]
-            values  = np.asarray(values)
+            values  = np.frombuffer(values, dtype = 'f4')
             for i in range(ntraces):
                 ifst = major[i*2]
                 ilst = major[i*2 + 1]

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -176,10 +176,14 @@ class assembler:
 
         xs = np.zeros(shape = shape[1:], dtype = np.single)
         for bundle in unpacked[1]:
-            ntraces = bundle[0]
-            major   = bundle[1]
-            minor   = bundle[2]
-            values  = bundle[3]
+            attribute = bundle[0]
+            if attribute != 'data':
+                continue
+
+            ntraces = bundle[1]
+            major   = bundle[2]
+            minor   = bundle[3]
+            values  = bundle[4]
             values  = np.asarray(values)
             for i in range(ntraces):
                 ifst = major[i*2]

--- a/python/oneseismic/decoder.cpp
+++ b/python/oneseismic/decoder.cpp
@@ -1,0 +1,76 @@
+#include <msgpack.hpp>
+
+#include <oneseismic/decoder.hpp>
+#include <oneseismic/messages.hpp>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace {
+
+void buffer(one::decoder& self, py::buffer b) {
+    auto info = b.request();
+    self.buffer(
+        reinterpret_cast< const char* >(info.ptr),
+        info.size * info.itemsize
+    );
+}
+
+one::decoder::status buffer_and_process(
+    one::decoder& self,
+    py::buffer b)
+{
+    auto info = b.request();
+    return self.buffer_and_process(
+        reinterpret_cast< const char* >(info.ptr),
+        info.size * info.itemsize
+    );
+}
+
+void register_writer(
+    one::decoder& self,
+    const std::string& key,
+    py::buffer b)
+{
+    auto info = b.request();
+    self.register_writer(key, info.ptr);
+}
+
+}
+
+PYBIND11_MODULE(decoder, m) {
+    py::class_<one::process_header>(m, "header")
+        .def_readonly("attrs",      &one::process_header::attributes)
+        .def_readonly("ndims",      &one::process_header::ndims)
+        .def_readonly("index",      &one::process_header::index)
+        .def_readonly("function",   &one::process_header::function)
+    ;
+
+    py::enum_<one::functionid>(m, "functionid")
+        .value("slice",     one::functionid::slice)
+        .value("curtain",   one::functionid::curtain)
+        .export_values()
+    ;
+
+    py::class_<one::decoder> decoder(m, "decoder");
+    decoder
+        .def(py::init<>())
+        .def("reset",               &one::decoder::reset)
+        .def("process",             &one::decoder::process)
+        .def("buffer",              buffer)
+        .def("buffer_and_process",  buffer_and_process)
+        .def("header",              &one::decoder::header,
+                                        py::return_value_policy::copy)
+        .def("register_writer",     register_writer)
+    ;
+
+    using status = one::decoder::status;
+    py::enum_<status>(decoder, "status")
+        .value("paused", status::paused)
+        .value("done",   status::done)
+        .export_values()
+    ;
+
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,4 +3,20 @@ requires = [
     "setuptools >= 40",
     "scikit-build",
     "wheel",
+    "pybind11",
 ]
+
+[tool.cibuildwheel]
+before-all = [
+    "curl -L https://github.com/msgpack/msgpack-c/releases/download/cpp-3.3.0/msgpack-3.3.0.tar.gz -o msgpack-3.3.0.tar.gz",
+    "tar xf msgpack-3.3.0.tar.gz",
+]
+before-build = [
+    "cmake -S msgpack-3.3.0 -B msgpack-3.3.0/build -DMSGPACK_CXX_ONLY=ON -DMSGPACK_BUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=core/",
+    "cmake --build msgpack-3.3.0/build --target install --config Release",
+    "cmake -S core/ -B build/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DBUILD_CORE=OFF",
+    "cmake --build build/ -j 4 --target install --config Release",
+]
+
+[tool.cibuildwheel.macos]
+environment = { CXXFLAGS="-L/usr/local/lib" }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = [
     "setuptools >= 40",
+    "scikit-build",
     "wheel",
 ]

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -5,8 +5,10 @@ msal
 numpy
 pytest
 pytest-runner
+pybind11
 requests
 requests_mock
+scikit-build
 segyio
 tqdm
 xdg

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -8,14 +8,6 @@ url = https://github.com/equinor/oneseismic
 version = 0.2.1
 
 [options]
-packages =
-    oneseismic
-    oneseismic.client
-    oneseismic.internal
-    oneseismic.login
-    oneseismic.scan
-    oneseismic.upload
-
 install_requires =
     azure-storage-blob
     gql
@@ -30,6 +22,8 @@ install_requires =
 
 setup_requires =
     pytest-runner
+    scikit-build
+    pybind11
 
 tests_require =
     hypothesis

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 
-import setuptools
+import skbuild
 
 if __name__ == "__main__":
-    setuptools.setup()
+    skbuild.setup(
+        packages = [
+            'oneseismic',
+            'oneseismic.client',
+            'oneseismic.internal',
+            'oneseismic.login',
+            'oneseismic.scan',
+            'oneseismic.upload',
+        ],
+    )


### PR DESCRIPTION
There's actually a couple of (somewhat related) changes in this PR, but it brings two major improvements.

## Performance improvements
I measured the time taken by parse+extract _after_ all data was downloaded before and after this PR.

    NEW
        0.001031s
        0.000731s
    OLD
        0.024170s
        0.020067s

Which means that in parsing and extracting alone this brings 20-30x performance improvement.

## Message format
The message format has been reviewed, and the (main) payload is no longer serialized as an array, but rather bin. The messagepack binary type is really just length + blob, and leaves the actual format to the application. In this case we know it's float32 little-endian, which brings down overhead (1 byte per element) and reduces serialization cost. Most of the performance improvements come from this change.

## C++ decoder
I've written a decoder in C++ that should cover the needs of all clients, which should implement an efficient protocol and streaming, and make it (slightly) easier to tune the message format. This is a design choice, since a C++ decoder can be used from virtually all languages. The main driver here is Javascript; we can provide an emscripten lib that JS clients can use to leverage oneseismic directly from the browser.

The C++ decoder brings _some_ performance gains (mostly in predictability), but it is not yet used in a streaming fashion.

## Misc
Some good tests are sorely missing, but right now the format is in significant flux, and a test suite for the decoder needs to be planned and executed well if it is to make any sense. This should probably be prioritised soon.