### PR TITLE
Don't do blocking read on failure channel

### DIFF
--- a/api/api/result.go
+++ b/api/api/result.go
@@ -165,11 +165,11 @@ func (r *Result) Get(ctx *gin.Context) {
 		result = append(result, tile...)
 	}
 
-	err, ok := <-failure
-
-	if ok {
-		log.Printf("pid=%s, %s", pid, err)
+	select {
+	case err = <-failure:
 		ctx.AbortWithStatus(http.StatusInternalServerError)
+		return
+	default:
 	}
 
 	ctx.Data(http.StatusOK, "application/octet-stream", result)


### PR DESCRIPTION
This is a bug in the /result that's been there since it was written. It
accidentally worked when the failure channel was closed in collectResult
(which it shouldn't be).

err, ok := <-failure will block until there is a message on the channel
*or* it is closed, but its intention is to read a message if available,
otherwise just continue.

Replace it with a select { case ...; default } which actually has this
behaviour.