### PR TITLE
Send allocation hints in response

### DIFF
--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -211,6 +211,11 @@ type sliceargs struct {
 	Val  int32  `json:"val"`
 }
 
+type curtainargs struct {
+	Kind   string    `json:"kind"`
+	Coords [][]int32 `json:"coords"`
+}
+
 func (c *cube) SliceByLineno(
 	ctx  context.Context,
 	args struct {
@@ -318,9 +323,35 @@ func (c *cube) basicSlice(
 	}, nil
 }
 
-func (c *cube) Curtain(
+func (c *cube) CurtainByIndex(
 	ctx    context.Context,
 	args   struct { Coords [][]int32 `json:"coords"` },
+) (*promise, error) {
+	return c.basicCurtain(
+		ctx,
+		curtainargs {
+			Kind: "index",
+			Coords: args.Coords,
+		},
+	)
+}
+
+func (c *cube) CurtainByLineno(
+	ctx    context.Context,
+	args   struct { Coords [][]int32 `json:"coords"` },
+) (*promise, error) {
+	return c.basicCurtain(
+		ctx,
+		curtainargs {
+			Kind: "lineno",
+			Coords: args.Coords,
+		},
+	)
+}
+
+func (c *cube) basicCurtain(
+	ctx    context.Context,
+	args   curtainargs,
 ) (*promise, error) {
 	keys := ctx.Value("keys").(map[string]string)
 	pid  := keys["pid"]
@@ -412,7 +443,8 @@ type Cube {
 
     sliceByLineno(dim: Int!, lineno: Int!, opts: Opts): Promise!
     sliceByIndex(dim: Int!, index: Int!, opts: Opts): Promise!
-    curtain(coords: [[Int!]!]!): Promise!
+    curtainByLineno(coords: [[Int!]!]!): Promise!
+    curtainByIndex(coords: [[Int!]!]!): Promise!
 }
 
 type Promise {

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -172,7 +172,9 @@ struct process_header : MsgPackable< process_header > {
     int                                 nbundles;
     int                                 ndims;
     std::vector< int >                  index;
+    std::vector< std::string >          labels;
     std::vector< std::string >          attributes;
+    std::vector< int >                  shapes;
 };
 
 struct slice_query : public basic_query, Packable< slice_query > {

--- a/core/src/decoder.cpp
+++ b/core/src/decoder.cpp
@@ -49,7 +49,9 @@ struct convert< one::process_header > {
             else if (key == "function")   kv.val >> head.function;
             else if (key == "nbundles")   kv.val >> head.nbundles;
             else if (key == "ndims")      kv.val >> head.ndims;
+            else if (key == "labels")     kv.val >> head.labels;
             else if (key == "index")      kv.val >> head.index;
+            else if (key == "shapes")     kv.val >> head.shapes;
             else if (key == "attributes") kv.val >> head.attributes;
             else {
                 throw one::bad_message("Unknown key '" + key + "' in header");

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -269,6 +269,8 @@ void to_json(nlohmann::json& doc, const process_header& head) noexcept (false) {
     doc["nbundles"]     = head.nbundles;
     doc["ndims"]        = head.ndims;
     doc["index"]        = head.index;
+    doc["labels"]       = head.labels;
+    doc["shapes"]       = head.shapes;
     doc["attributes"]   = head.attributes;
 }
 
@@ -278,6 +280,8 @@ void from_json(const nlohmann::json& doc, process_header& head) noexcept (false)
     doc.at("nbundles")  .get_to(head.nbundles);
     doc.at("ndims")     .get_to(head.ndims);
     doc.at("index")     .get_to(head.index);
+    doc.at("labels")    .get_to(head.labels);
+    doc.at("shapes")    .get_to(head.shapes);
     doc.at("attributes").get_to(head.attributes);
 }
 

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -347,7 +347,12 @@ schedule_maker< slice_query, slice_task >::header(
     head.function   = functionid::slice;
     head.nbundles   = ntasks;
     head.ndims      = mdims.size() - 1;
-    head.attributes = query.attributes;
+    head.attributes.push_back("data");
+    head.attributes.insert(
+        head.attributes.end(),
+        query.attributes.begin(),
+        query.attributes.end()
+    );
 
     /*
      * Build the index from the line numbers for the directions !=
@@ -469,7 +474,12 @@ schedule_maker< curtain_query, curtain_task >::header(
     head.function   = functionid::curtain;
     head.nbundles   = ntasks;
     head.ndims      = mdims.size();
-    head.attributes = query.attributes;
+    head.attributes.push_back("data");
+    head.attributes.insert(
+        head.attributes.end(),
+        query.attributes.begin(),
+        query.attributes.end()
+    );
 
     auto& index = head.index;
 

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -334,6 +334,16 @@ schedule_maker< slice_query, slice_task >::build(const slice_query& query) {
     return tasks;
 }
 
+namespace {
+
+bool horizontal(const slice_query& query) noexcept (true) {
+    const auto querydims = query.manifest.line_numbers.size();
+    const auto last_dim = querydims - 1;
+    return query.dim == last_dim;
+}
+
+}
+
 template <>
 process_header
 schedule_maker< slice_query, slice_task >::header(
@@ -346,7 +356,8 @@ schedule_maker< slice_query, slice_task >::header(
     head.pid        = query.pid;
     head.function   = functionid::slice;
     head.nbundles   = ntasks;
-    head.ndims      = mdims.size() - 1;
+    head.ndims      = mdims.size();
+    head.labels     = query.manifest.line_labels;
     head.attributes.push_back("data");
     head.attributes.insert(
         head.attributes.end(),
@@ -355,17 +366,66 @@ schedule_maker< slice_query, slice_task >::header(
     );
 
     /*
-     * Build the index from the line numbers for the directions !=
-     * params.lineno
+     * Build the (line number) index of the output. Notice that the queried
+     * direction is also included here, so that users can get infer what line
+     * was queried (useful when source is index or coordinate) and the
+     * direction of the output.
      */
     for (std::size_t i = 0; i < mdims.size(); ++i) {
-        if (i == query.dim) continue;
-        head.index.push_back(mdims[i].size());
+        if (i != query.dim) {
+            head.index.push_back(mdims[i].size());
+        } else {
+            head.index.push_back(1);
+        }
     }
     for (std::size_t i = 0; i < mdims.size(); ++i) {
-        if (i == query.dim) continue;
-        head.index.insert(head.index.end(), mdims[i].begin(), mdims[i].end());
+        if (i != query.dim) {
+            head.index.insert(
+                head.index.end(),
+                mdims[i].begin(),
+                mdims[i].end()
+            );
+        } else {
+            head.index.push_back(mdims[i][query.idx]);
+        }
     }
+
+    /*
+     * Record the shapes of the output. The first attribute is always 'data'
+     * (the payload/values/trace values), and its shape always matches those of
+     * the index. One of the dimensions is 1 (e.g. when querying an inline, the
+     * first dimension is 1), so users with numpy probably wants to squeeze the
+     * array before use. How to handle these 1-dimensions is left to the users.
+     */
+    auto& shapes = head.shapes;
+    shapes.push_back(head.ndims);
+    shapes.insert(
+        shapes.end(),
+        head.index.begin(),
+        head.index.begin() + head.ndims
+    );
+
+    for (const auto& attr : query.attributes) {
+        shapes.push_back(head.ndims);
+        shapes.insert(
+            shapes.end(),
+            head.index.begin(),
+            head.index.begin() + head.ndims
+        );
+
+        /*
+         * If the query is vertical (in/crossline) then the attributes should
+         * all be 1D arrays (one-per-trace). When it is a time/depth slice, the
+         * output is a field and the attributes are 2D. This maps the attribute
+         * shapes from/to:
+         *
+         * dim0: [1, N, M] -> [1, N, 1]
+         * dim1: [N, 1, M] -> [N, 1, 1]
+         * dim2: [N, M, 1] -> [N, M, 1]
+         */
+        shapes.back() = 1;
+    }
+
     return head;
 }
 
@@ -474,6 +534,7 @@ schedule_maker< curtain_query, curtain_task >::header(
     head.function   = functionid::curtain;
     head.nbundles   = ntasks;
     head.ndims      = mdims.size();
+    head.labels     = query.manifest.line_labels;
     head.attributes.push_back("data");
     head.attributes.insert(
         head.attributes.end(),
@@ -490,6 +551,19 @@ schedule_maker< curtain_query, curtain_task >::header(
     index.insert(index.end(), query.dim0s .begin(), query.dim0s .end());
     index.insert(index.end(), query.dim1s .begin(), query.dim1s .end());
     index.insert(index.end(), mdims.back().begin(), mdims.back().end());
+
+    /*
+     * The curtain is already pretty constrained in its output shapes, since it
+     * can only query "vertically", which makes attributes always 1D
+     */
+    auto& shapes = head.shapes;
+    shapes.push_back(2);
+    shapes.insert(shapes.end(), index.begin() + 1, index.begin() + 3);
+
+    for (const auto& attr : query.attributes) {
+        shapes.push_back(1);
+        shapes.push_back(head.index.front());
+    }
 
     return head;
 }

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -364,7 +364,7 @@ class cube:
         query = f'''
         query {{
             cube(id: "{self.guid}") {{
-                curtain(coords: {intersections}) {{
+                curtainByLineno(coords: {intersections}) {{
                     url
                     key
                 }}

--- a/python/oneseismic/decoder.cpp
+++ b/python/oneseismic/decoder.cpp
@@ -46,6 +46,8 @@ PYBIND11_MODULE(decoder, m) {
         .def_readonly("ndims",      &one::process_header::ndims)
         .def_readonly("index",      &one::process_header::index)
         .def_readonly("function",   &one::process_header::function)
+        .def_readonly("shapes",     &one::process_header::shapes)
+        .def_readonly("labels",     &one::process_header::labels)
     ;
 
     py::enum_<one::functionid>(m, "functionid")


### PR DESCRIPTION
Motivation
----------
The server has more information about the query and request than the
decoder and mapping to the user environment want to juggle, so add axis
labels (inline, crossline, time, depth etc) and shape hints to the
response.

Having this information in the message makes for a much nicer user
experience when decoding, since the decoder does no longer depend on
information from when the request was *made*. This gives the response
some interesting properties:

1. When distributing the results to worker nodes, they only need the
   promise, since the response itself has enough information to make
   proper sense of it. It makes workers easier to write and more
   independent, since they can be reduced to simple response processers.
2. Much simpler decoding; get an instance, give it some bytes, and read
   the results, done. No longer passing metadata along with the decoder
   to populate xarray etc.
3. Much simpler allocation, since the shape of every output is a part of
   the message. Simply read the shape array and pass to the allocation
   function.
4. The message can encode the "direction" of the slices, since it
   explicitly includes the 1-dimension.
5. No longer mis-labeling of axis by the xarray() method, since it now
   gets the axis labels from the authoriative source, rather than guessing.

Important details: 1-dimensions
-------------------------------
This commit brings a subtle change that is worth an extra section. When
querying a slice from a 3D volume, the result is a 2D structure. With
this patch, the shape is always 3D [1], but one of the dimensions have
size 1.

    inline:     [1, N, M]
    crossline:  [N, 1, M]
    time/depth: [N, M, 1]

For allocation purposes, this is inconsequential; the size is prod(dims)
anyway, and it describes the same structure. Including the dimension
makes some code paths a lot simpler, since the "removed" dimension no
longer has to be special cased. To obtain the "real" 2D structure,
arrays come with squeeze() methods and similar.

With this change, the header.labels array maps (through positions)
nicely onto the shapes and index, and it is up to user programs if they
want to report on it or just discard the extra dimensions.

Immediate benefits
------------------
The decoding and unpacking code in python is largely removed; decode()
will allocate, and xarray maps the decoded response into xarray's input.
The new implementation doesn't hard code anything anymore, and better
populates the xarrays. Here are some example outputs from querying
slices in all three dimensions and a curtain:

    -- name field is properly set
    -- coordinate dimensions and names are inferred (time!)
    -- the queried attribute (inline: 10261) is properly set
    <xarray.DataArray 'inline slice 10261' (crossline: 720, time: 850)>
    array([[ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
             0.0000000e+00,  0.0000000e+00,  0.0000000e+00],
           [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
             0.0000000e+00,  0.0000000e+00,  0.0000000e+00],
           [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
             0.0000000e+00,  0.0000000e+00,  0.0000000e+00],
           ...,
           [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
            -1.1615995e-02,  1.2507305e-02,  0.0000000e+00],
           [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
            -4.3828748e-03,  2.0183403e-02,  0.0000000e+00],
           [ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
            -4.2640328e-05,  3.5810769e-02,  0.0000000e+00]], dtype=float32)
    Coordinates:
      * crossline  (crossline) int64 1961 1962 1963 1964 ... 2677 2678 2679 2680
      * time       (time) int64 0 4000 8000 12000 ... 3388000 3392000 3396000
    Attributes:
        inline:   10261

    <xarray.DataArray 'crossline slice 2111' (inline: 201, time: 850)>
    array([[0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           ...,
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.]], dtype=float32)
    Coordinates:
      * inline   (inline) int64 9961 9963 9965 9967 9969 ... 10355 10357 10359 10361
      * time     (time) int64 0 4000 8000 12000 ... 3384000 3388000 3392000 3396000
    Attributes:
        crossline:  2111

    <xarray.DataArray 'time slice 600000' (inline: 201, crossline: 720)>
    array([[0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           ...,
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.]], dtype=float32)
    Coordinates:
      * inline     (inline) int64 9961 9963 9965 9967 ... 10355 10357 10359 10361
      * crossline  (crossline) int64 1961 1962 1963 1964 ... 2677 2678 2679 2680
    Attributes:
        time:     600000

    -- both inline and crosslines coordinates are set
    <xarray.DataArray 'curtain' (x, y: 201, time: 850)>
    array([[0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           ...,
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.]], dtype=float32)
    Coordinates:
        inline     (x, y) int64 0 1 2 3 4 5 6 7 ... 193 194 195 196 197 198 199 200
        crossline  (x, y) int64 360 360 360 360 360 360 ... 360 360 360 360 360 360
      * time       (time) int64 0 4000 8000 12000 ... 3388000 3392000 3396000
    Dimensions without coordinates: x, y

This is opposed to the old curtain xarray, which had a long and somewhat
complicated implementation, and still labelled poorly:

    <xarray.DataArray 'curtain' (xy: 201, z: 850)>
    array([[0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           ...,
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.]], dtype=float32)
    Coordinates:
        x        (xy) int64 9961 9963 9965 9967 9969 ... 10355 10357 10359 10361
        y        (xy) int64 2321 2321 2321 2321 2321 ... 2321 2321 2321 2321 2321
      * z        (z) int64 0 4000 8000 12000 ... 3384000 3388000 3392000 3396000
    Dimensions without coordinates: xy

Notice that it uses x/y/z rather than inline/crossline/time.

[1] Some sections are aware of ND volumes, but this is not really a
    reality in oneseismic yet