### PR TITLE
Nullable and scalar promises

### DIFF
--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -31,9 +31,24 @@ type cube struct {
 	root     *resolver
 	manifest map[string]interface{}
 }
+
 type promise struct {
-	url string
-	key string
+	Url string `json:"url"`
+	Key string `json:"key"`
+}
+
+func (promise) ImplementsGraphQLType(name string) bool {
+	return name == "Promise"
+}
+
+func (p *promise) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+func (p *promise) UnmarshalGraphQL(input interface{}) error {
+	// Unmarshal must be defined, but should never be used as an input type;
+	// that's a schema bug, and all queries should be ignored.
+	return errors.New("Promise is not an input type");
 }
 
 type opts struct {
@@ -318,8 +333,8 @@ func (c *cube) basicSlice(
 	}()
 
 	return &promise {
-		url: fmt.Sprintf("result/%s", pid),
-		key: key,
+		Url: fmt.Sprintf("result/%s", pid),
+		Key: key,
 	}, nil
 }
 
@@ -401,17 +416,9 @@ func (c *cube) basicCurtain(
 	}()
 
 	return &promise {
-		url: fmt.Sprintf("result/%s", pid),
-		key: key,
+		Url: fmt.Sprintf("result/%s", pid),
+		Key: key,
 	}, nil
-}
-
-func (p *promise) Url() string {
-	return p.url
-}
-
-func (p *promise) Key() string {
-	return p.key
 }
 
 func MakeGraphQL(
@@ -421,6 +428,8 @@ func MakeGraphQL(
 	tokens   auth.Tokens,
 ) *gql {
 	schema := `
+scalar Promise
+
 type Query {
     cubes: [ID!]!
     cube(id: ID!): Cube!
@@ -445,11 +454,6 @@ type Cube {
     sliceByIndex(dim: Int!, index: Int!, opts: Opts): Promise
     curtainByLineno(coords: [[Int!]!]!): Promise
     curtainByIndex(coords: [[Int!]!]!): Promise
-}
-
-type Promise {
-    url: String!
-    key: String!
 }
 	`
 	resolver := &resolver {

--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -280,7 +280,7 @@ func (c *cube) basicSlice(
 		// just-about to expire then the process will fail pretty soon anyway,
 		// so just give up.
 		log.Printf("pid=%s, %v", pid, err)
-		return nil, err
+		return nil, errors.New("internal error; bad token?")
 	}
 
 	msg := message.Query {
@@ -296,13 +296,13 @@ func (c *cube) basicSlice(
 	query, err := c.root.sched.MakeQuery(&msg)
 	if err != nil {
 		log.Printf("pid=%s, %v", pid, err)
-		return nil, err
+		return nil, nil
 	}
 
 	key, err := c.root.keyring.Sign(pid)
 	if err != nil {
 		log.Printf("pid=%s, %v", pid, err)
-		return nil, err
+		return nil, errors.New("internal error")
 	}
 
 	go func () {
@@ -364,7 +364,7 @@ func (c *cube) basicCurtain(
 		// just-about to expire then the process will fail pretty soon anyway,
 		// so just give up.
 		log.Printf("pid=%s, %v", pid, err)
-		return nil, err
+		return nil, errors.New("internal error; bad token?")
 	}
 
 	msg := message.Query {
@@ -379,13 +379,13 @@ func (c *cube) basicCurtain(
 	query, err := c.root.sched.MakeQuery(&msg)
 	if err != nil {
 		log.Printf("pid=%s, %v", pid, err)
-		return nil, err
+		return nil, nil
 	}
 
 	key, err := c.root.keyring.Sign(pid)
 	if err != nil {
 		log.Printf("pid=%s, %v", pid, err)
-		return nil, err
+		return nil, errors.New("internal error")
 	}
 
 	go func () {
@@ -441,10 +441,10 @@ type Cube {
 
     linenumbers: [[Int!]!]!
 
-    sliceByLineno(dim: Int!, lineno: Int!, opts: Opts): Promise!
-    sliceByIndex(dim: Int!, index: Int!, opts: Opts): Promise!
-    curtainByLineno(coords: [[Int!]!]!): Promise!
-    curtainByIndex(coords: [[Int!]!]!): Promise!
+    sliceByLineno(dim: Int!, lineno: Int!, opts: Opts): Promise
+    sliceByIndex(dim: Int!, index: Int!, opts: Opts): Promise
+    curtainByLineno(coords: [[Int!]!]!): Promise
+    curtainByIndex(coords: [[Int!]!]!): Promise
 }
 
 type Promise {

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -180,10 +180,7 @@ class cube:
         query = f'''
         query {{
             cube(id: "{self.guid}") {{
-                sliceByLineno(dim: {dim}, lineno: {lineno}) {{
-                    url
-                    key
-                }}
+                sliceByLineno(dim: {dim}, lineno: {lineno})
             }}
         }}
         '''
@@ -213,10 +210,7 @@ class cube:
         query = f'''
         query {{
             cube(id: "{self.guid}") {{
-                curtainByLineno(coords: {intersections}) {{
-                    url
-                    key
-                }}
+                curtainByLineno(coords: {intersections})
             }}
         }}
         '''

--- a/python/oneseismic/client/client.py
+++ b/python/oneseismic/client/client.py
@@ -377,6 +377,8 @@ def gschedule(client, base_url, query):
     res = client.execute(q)
 
     for promise in res['cube'].values():
+        if promise is None:
+            raise RuntimeError('Server unable to resolve query')
         url = promise['url']
         key = promise['key']
 


### PR DESCRIPTION
Nullable promises
==============
Using optional return values makes for a less brittle API, since even
promises could be just a small part of a larger query. This has no
python client support as of now (hence the awkward for loop for
extraction), but the API might as well support it.

For a motivating example, consider this query:

    cube(ids: $ids) {
        year
        sliceByLineno(dim: $dim, lineno: $lineno)
    }

IDs would be a set of independent surveys in the same area (e.g. North
Sea), which would return a specific line across a large area from the
candidate surveys. If a line is not a part of the survey then it is
simply skipped. For good measure the year is included to weed out very
old surveys. This would not work if the query would error after the
first line without a survey.

Applications, such as the python sdk, might want to ensure that errors
are raised when the query could not be fully resolved, but the API would
be right in returning what it could resolve and null the remaining
fields.

Scalar promises
============
Change the Promise from a struct { url; key; } to a scalar type. From
the GraphQL docs:

    A GraphQL object type has a name and fields, but at some point those
    fields have to resolve to some concrete data. That's where the
    scalar types come in: they represent the leaves of the query.

Scalars have application specific serialization, parsing, and
validation. The promise type is a pure output type in oneseismic, and
clients are expected to know that its content (which are unchanged, at
least for now).

This makes querying less annoying. The content of a Promise is useless
unless you have all the fields (url, key), so it makes no sense having
to specify them all. It transforms queries like this:

    # before
    cube(id: $id) {
        sliceByIndex(dim: $dim, index: $index) {
            key
            url
        }
    }

    # after
    cube(id: $id) {
        sliceByIndex(dim: $dim, index: $index)
    }