### PR TITLE
Bugfixes

### DIFF
--- a/api/api/scheduler.cpp
+++ b/api/api/scheduler.cpp
@@ -35,8 +35,8 @@ plan mkschedule(const char* doc, int len, int task_size) try {
 void cleanup(plan* p) {
     if (!p) return;
 
-    delete p->err;
-    delete p->sizes;
-    delete p->tasks;
+    delete[] p->err;
+    delete[] p->sizes;
+    delete[] p->tasks;
     *p = plan {};
 }

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -467,17 +467,16 @@ schedule_maker< curtain_query, curtain_task >::build(
 
     /*
      * Pre-allocate the id objects by scanning the input and build the
-     * one::single objects, sorted by id lexicographically. All fragments in
-     * the column (z-axis) are generated from the x-y pair. This is essentially
-     * constructing the "buckets" in advance, as many x/y pairs will end up in
-     * the same "bin"/fragment.
+     * one::single objects. All fragments in the column (z-axis) are generated
+     * from the x-y pair. This is essentially constructing the "buckets" in
+     * advance, as many x/y pairs will end up in the same "bin"/fragment.
      *
      * This is effectively
      *  ids = set([fragmentid(x, y, z) for z in zheight for (x, y) in input])
      *
      * but without any intermediary structures.
      *
-     * The bins are lexicographically sorted.
+     * The bins are sorted lexicographically by fragment ID.
      */
     for (int i = 0; i < int(dim0s.size()); ++i) {
         auto top_point = CP< 3 > {

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -548,8 +548,9 @@ schedule_maker< curtain_query, curtain_task >::header(
     index.push_back(query.dim1s .size());
     index.push_back(mdims.back().size());
 
-    index.insert(index.end(), query.dim0s .begin(), query.dim0s .end());
-    index.insert(index.end(), query.dim1s .begin(), query.dim1s .end());
+    const auto& line_numbers = query.manifest.line_numbers;
+    for (auto x : query.dim0s) index.push_back(line_numbers[0][x]);
+    for (auto x : query.dim1s) index.push_back(line_numbers[1][x]);
     index.insert(index.end(), mdims.back().begin(), mdims.back().end());
 
     /*


### PR DESCRIPTION
Use delete[] for new[]'d objects

--

In 61e4363, when curtainByIndex support was added, the to_cartesian_inplace was moved to the from_json so that the header building was consistent with the cartesian grid, but the header() function was never updated to map the index back into line numbers.

This patch fixes that bug, and brings the index back into in/crossline numbers.