### PR TITLE
Break up the scheduler_maker system into free overloaded functions

### DIFF
--- a/api/api/scheduler.cpp
+++ b/api/api/scheduler.cpp
@@ -35,8 +35,8 @@ plan mkschedule(const char* doc, int len, int task_size) try {
 void cleanup(plan* p) {
     if (!p) return;
 
-    delete p->err;
-    delete p->sizes;
-    delete p->tasks;
+    delete[] p->err;
+    delete[] p->sizes;
+    delete[] p->tasks;
     *p = plan {};
 }

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -467,17 +467,16 @@ schedule_maker< curtain_query, curtain_task >::build(
 
     /*
      * Pre-allocate the id objects by scanning the input and build the
-     * one::single objects, sorted by id lexicographically. All fragments in
-     * the column (z-axis) are generated from the x-y pair. This is essentially
-     * constructing the "buckets" in advance, as many x/y pairs will end up in
-     * the same "bin"/fragment.
+     * one::single objects. All fragments in the column (z-axis) are generated
+     * from the x-y pair. This is essentially constructing the "buckets" in
+     * advance, as many x/y pairs will end up in the same "bin"/fragment.
      *
      * This is effectively
      *  ids = set([fragmentid(x, y, z) for z in zheight for (x, y) in input])
      *
      * but without any intermediary structures.
      *
-     * The bins are lexicographically sorted.
+     * The bins are sorted lexicographically by fragment ID.
      */
     for (int i = 0; i < int(dim0s.size()); ++i) {
         auto top_point = CP< 3 > {

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -82,181 +82,6 @@ std::vector< std::string > normalized_attributes(const Query& q) {
     return attrs;
 }
 
-/*
- * Scheduling
- * ----------
- * Scheduling in this context means the process of:
- *   1. parse an incoming request, e.g. /slice/<dim>/<lineno>
- *   2. build all task descriptions (fragment id + what to extract from
- *      the fragment)
- *   3. split the set of tasks into units of work
- *
- * I/O, the sending of messages to worker nodes is outside this scope.
- *
- * It turns out that the high-level algorithm is largely independent of the
- * task description, so if the "task constructor" is dependency injected then
- * the overall algorithm can be shared between all endpoints.
- *
- * To make matters slightly more complicated, a lot of constraints and
- * functionality is encoded in the types used for messages. It *could*, and
- * still may in the future, be implemented with inheritance, but that approach
- * too comes with its own set of drawbacks.
- *
- * While the types are different, the algorithm *structure* is identical. This
- * makes it a good fit for templates. It comes with some complexity of
- * understanding, but makes adding new endpoints a lot easier, and the reuse of
- * implementation means shared improvements and faster correctness guarantees.
- *
- * This comes with a very real tax for comprehensibility. Templates do add some
- * noise, and the algorithm is split across multiple functions that can all be
- * customised. I anticipate little need for many customisations, but
- * supporting extra customisation points adds very little extra since it just
- * hooks into the machinery required by a single customisation point.
- *
- * The benefit is that adding new endpoints now is a *lot* easier and less
- * error prone.
- */
-
-/*
- * Default implementations and customization points for the scheduling steps.
- * In general, you should only need to implement build() and header() for new
- * endpoints, but partition() and make() are made availble should there be a
- * need to customize them too.
- */
-template < typename Input, typename Output >
-struct schedule_maker {
-    /*
-     * Build the schedule - parse the incoming request and build the set of
-     * fragment IDs and extraction descriptions. This function is specific to
-     * the shape (slice, curtain, horizon etc) and comes with no default
-     * implementation.
-     *
-     * The Output type should have a pack() method that returns a std::string
-     */
-    std::vector< Output > build(const Input&) noexcept (false);
-
-    /*
-     * Make a header. This function requires deep knowledge of the shape and
-     * oneseismic geometry, and must be implemented for all shape types.
-     *
-     * The information in the process header is crucial for efficient and
-     * precise assembly of the end-result on the client side. Otherwise,
-     * clients must buffer the full response, then parse it and make sense of
-     * the shape, keys, linenos etc after the fact, since data can arrive in
-     * arbitrary order. This makes detecting errors more difficult too. The
-     * process header should provide enough information for clients to properly
-     * pre-allocate and build metadata to make sense of data as it is streamed.
-     */
-    process_header
-    header(const Input&, int ntasks) noexcept (false);
-
-    /*
-     * Partition partitions an Output in-place and pack()s it into blobs of
-     * task_size jobs. It assumes the Output type has a vector-like member
-     * called 'ids'. This is a name lookup - should the member be named
-     * something else or accessed in a different way then you must implement a
-     * custom partition().
-     *
-     * This function shall return \0-separated packed tasks. The last task
-     * shall be terminated with a \0, so that partition.count() can be
-     * implemented as std::count(begin, end, '\0'). While it is a slightly
-     * surprising interface (the most straight-forward would be
-     * vector-of-string), it makes processing the set-of-tasks slightly easier,
-     * saves a few allocations, and signals that the output is a bag of bytes.
-     */
-    taskset partition(std::vector< Output >&, int task_size) noexcept (false);
-
-    /*
-     * Make a schedule() - calls build(), header(), and partition() in
-     * sequence. The output vector should always have the header() as the
-     * *last* element.
-     */
-    taskset schedule(const char* doc, int len, int task_size) noexcept (false);
-};
-
-template< typename Outputs >
-int count_tasks(const Outputs& outputs, int task_size) noexcept (true) {
-    const auto add = [task_size](auto acc, const auto& elem) noexcept (true) {
-        return acc + task_count(elem.ids.size(), task_size);
-    };
-    return std::accumulate(outputs.begin(), outputs.end(), 0, add);
-}
-
-template < typename Input, typename Output >
-taskset schedule_maker< Input, Output >::partition(
-    std::vector< Output >& outputs,
-    int task_size
-) noexcept (false) {
-    if (task_size < 1) {
-        const auto msg = fmt::format("task_size (= {}) < 1", task_size);
-        throw std::logic_error(msg);
-    }
-
-    taskset partitioned;
-    partitioned.reserve(count_tasks(outputs, task_size));
-
-    for (auto& output : outputs) {
-        const auto ids = output.ids;
-        const auto ntasks = task_count(ids.size(), task_size);
-
-        using std::begin;
-        using std::end;
-        auto fst = begin(ids);
-        auto lst = end(ids);
-
-        for (int i = 0; i < ntasks; ++i) {
-            const auto last = std::min(fst + task_size, lst);
-            output.ids.assign(fst, last);
-            std::advance(fst, last - fst);
-            partitioned.append(output.pack());
-        }
-    }
-
-    return partitioned;
-}
-
-std::string pack_with_envelope(const process_header& head) {
-    /*
-     * The response message format is designed in such as way that the clients
-     * can choose to buffer and parse the message in one go, or stream it. This
-     * means that the message *as a whole* must be valid msgpack message, and
-     * not just a by-convention concatenation of independent messages.
-     *
-     * The whole response as msgpack looks like this:
-     * [header, [part1, part2, part3, ...]]
-     *
-     * which in bytes looks like:
-     * array(2) header array(n) part1 part2 part3
-     *
-     * where "space" means concatenation, and array(k) is array type tag and
-     * length. This functions add these array tags around the header.
-     */
-    std::stringstream buffer;
-    msgpack::packer< decltype(buffer) > packer(buffer);
-    packer.pack_array(2);
-    buffer << head.pack();
-    packer.pack_array(head.nbundles);
-    return buffer.str();
-}
-
-template < typename Input, typename Output >
-taskset schedule_maker< Input, Output >::schedule(
-        const char* doc,
-        int len,
-        int task_size)
-noexcept (false) {
-    Input in;
-    in.unpack(doc, doc + len);
-    in.attributes = normalized_attributes(in);
-    auto fetch = this->build(in);
-    auto sched = this->partition(fetch, task_size);
-
-    const auto ntasks = int(sched.count());
-    const auto head   = this->header(in, ntasks);
-    sched.append(pack_with_envelope(head));
-    return sched;
-}
-
 template < typename Query >
 auto find_desc(const Query& query, const std::string& attr)
 -> decltype(query.manifest.attr.begin()) {
@@ -291,9 +116,7 @@ void append_vector_ids(
     std::transform(begin(src), end(src), append, to_vec);
 }
 
-template <>
-std::vector< slice_task >
-schedule_maker< slice_query, slice_task >::build(const slice_query& query) {
+std::vector< slice_task > build(const slice_query& query) {
     auto task = slice_task(query);
     std::vector< slice_task > tasks;
     tasks.reserve(query.attributes.size() + 1);
@@ -334,22 +157,8 @@ schedule_maker< slice_query, slice_task >::build(const slice_query& query) {
     return tasks;
 }
 
-namespace {
-
-bool horizontal(const slice_query& query) noexcept (true) {
-    const auto querydims = query.manifest.line_numbers.size();
-    const auto last_dim = querydims - 1;
-    return query.dim == last_dim;
-}
-
-}
-
-template <>
-process_header
-schedule_maker< slice_query, slice_task >::header(
-    const slice_query& query,
-    int ntasks
-) noexcept (false) {
+process_header header(const slice_query& query, int ntasks)
+noexcept (false) {
     const auto& mdims = query.manifest.line_numbers;
 
     process_header head;
@@ -429,11 +238,7 @@ schedule_maker< slice_query, slice_task >::header(
     return head;
 }
 
-template <>
-std::vector< curtain_task >
-schedule_maker< curtain_query, curtain_task >::build(
-    const curtain_query& query)
-{
+std::vector< curtain_task > build(const curtain_query& query) {
     const auto less = [](const auto& lhs, const auto& rhs) noexcept (true) {
         return std::lexicographical_compare(
             lhs.id.begin(),
@@ -520,12 +325,8 @@ schedule_maker< curtain_query, curtain_task >::build(
     return tasks;
 }
 
-template <>
-process_header
-schedule_maker< curtain_query, curtain_task >::header(
-    const curtain_query& query,
-    int ntasks
-) noexcept (false) {
+process_header header( const curtain_query& query, int ntasks)
+noexcept (false) {
     const auto& mdims = query.manifest.line_numbers;
 
     process_header head;
@@ -568,6 +369,150 @@ schedule_maker< curtain_query, curtain_task >::header(
     return head;
 }
 
+
+
+template< typename Outputs >
+int count_tasks(const Outputs& outputs, int task_size) noexcept (true) {
+    const auto add = [task_size](auto acc, const auto& elem) noexcept (true) {
+        return acc + task_count(elem.ids.size(), task_size);
+    };
+    return std::accumulate(outputs.begin(), outputs.end(), 0, add);
+}
+
+/*
+ * Partitions an Output in-place and pack()s it into blobs of task_size jobs.
+ * It assumes the Output type has a vector-like member called 'ids'. This is a
+ * name lookup - should the member be named something else or accessed in a
+ * different way then you must implement a custom partition().
+ *
+ * This function shall return \0-separated packed tasks. The last task
+ * shall be terminated with a \0, so that partition.count() can be
+ * implemented as std::count(begin, end, '\0'). While it is a slightly
+ * surprising interface (the most straight-forward would be
+ * vector-of-string), it makes processing the set-of-tasks slightly easier,
+ * saves a few allocations, and signals that the output is a bag of bytes.
+ */
+template < typename Output >
+taskset partition(std::vector< Output >& outputs, int task_size)
+noexcept (false) {
+    if (task_size < 1) {
+        const auto msg = fmt::format("task_size (= {}) < 1", task_size);
+        throw std::logic_error(msg);
+    }
+
+    taskset partitioned;
+    partitioned.reserve(count_tasks(outputs, task_size));
+
+    for (auto& output : outputs) {
+        const auto ids = output.ids;
+        const auto ntasks = task_count(ids.size(), task_size);
+
+        using std::begin;
+        using std::end;
+        auto fst = begin(ids);
+        auto lst = end(ids);
+
+        for (int i = 0; i < ntasks; ++i) {
+            const auto last = std::min(fst + task_size, lst);
+            output.ids.assign(fst, last);
+            std::advance(fst, last - fst);
+            partitioned.append(output.pack());
+        }
+    }
+
+    return partitioned;
+}
+
+std::string pack_with_envelope(const process_header& head) {
+    /*
+     * The response message format is designed in such as way that the clients
+     * can choose to buffer and parse the message in one go, or stream it. This
+     * means that the message *as a whole* must be valid msgpack message, and
+     * not just a by-convention concatenation of independent messages.
+     *
+     * The whole response as msgpack looks like this:
+     * [header, [part1, part2, part3, ...]]
+     *
+     * which in bytes looks like:
+     * array(2) header array(n) part1 part2 part3
+     *
+     * where "space" means concatenation, and array(k) is array type tag and
+     * length. This functions add these array tags around the header.
+     */
+    std::stringstream buffer;
+    msgpack::packer< decltype(buffer) > packer(buffer);
+    packer.pack_array(2);
+    buffer << head.pack();
+    packer.pack_array(head.nbundles);
+    return buffer.str();
+}
+
+/*
+ * Scheduling
+ * ----------
+ * Scheduling in this context means the process of:
+ *   1. parse an incoming request
+ *   2. build all task descriptions (fragment id + what to extract from
+ *      the fragment)
+ *   3. split the set of tasks into units of work
+ *
+ * I/O, the sending of messages to worker nodes is outside this scope.
+ *
+ * It turns out that the high-level algorithm is largely independent of the
+ * task description, so if the "task constructor" is dependency injected then
+ * the overall algorithm can be shared between all endpoints.
+ *
+ * To make matters slightly more complicated, a lot of constraints and
+ * functionality is encoded in the types used for messages. It *could*, and
+ * still may in the future, be implemented with inheritance, but that approach
+ * too comes with its own set of drawbacks.
+ *
+ * While the types are different, the algorithm *structure* is identical. This
+ * makes it a good fit for templates. It comes with some complexity of
+ * understanding, but makes adding new endpoints a lot easier, and the reuse of
+ * implementation means shared improvements and faster correctness guarantees.
+ *
+ * It relies on a few types, functions, and their contracts:
+ *
+ * Input (type)
+ *  like the messages *_query family
+ * Output (type)
+ *  like the messages *_task family
+ *  The Output type should have a pack() method that returns a std::string
+ *
+ * vector< Output > build(Input)
+ *  Build the schedule - parse the incoming request and build the set of
+ *  fragment IDs and extraction descriptions. This function is specific to
+ *  the shape (slice, curtain, horizon etc) and comes with no default
+ *  implementation.
+ *
+ * process_header header(Input, ntasks)
+ *  Make a header. This function requires deep knowledge of the shape and
+ *  oneseismic geometry, and must be implemented for all shape types.
+ *
+ *  The information in the process header is crucial for efficient and precise
+ *  assembly of the end-result on the client side. Otherwise, clients must
+ *  buffer the full response, then parse it and make sense of the shape, keys,
+ *  linenos etc after the fact, since data can arrive in arbitrary order. This
+ *  makes detecting errors more difficult too. The process header should
+ *  provide enough information for clients to properly pre-allocate and build
+ *  metadata to make sense of data as it is streamed.
+ */
+
+template < typename Input, typename Output >
+taskset schedule(const char* doc, int len, int task_size)
+noexcept (false) {
+    Input in;
+    in.unpack(doc, doc + len);
+    in.attributes = normalized_attributes(in);
+    auto fetch = build(in);
+    auto sched = partition(fetch, task_size);
+    const auto ntasks = int(sched.count());
+    const auto head   = header(in, ntasks);
+    sched.append(pack_with_envelope(head));
+    return sched;
+}
+
 }
 
 taskset mkschedule(const char* doc, int len, int task_size) noexcept (false) {
@@ -590,12 +535,10 @@ taskset mkschedule(const char* doc, int len, int task_size) noexcept (false) {
 
     const std::string function = document.at("function");
     if (function == "slice") {
-        auto slice = schedule_maker< slice_query, slice_task >{};
-        return slice.schedule(doc, len, task_size);
+        return schedule< slice_query, slice_task >(doc, len, task_size);
     }
     if (function == "curtain") {
-        auto curtain = schedule_maker< curtain_query, curtain_task >{};
-        return curtain.schedule(doc, len, task_size);
+        return schedule< curtain_query, curtain_task > (doc, len, task_size);
     }
     throw std::logic_error("No handler for function " + function);
 }

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -499,10 +499,9 @@ std::string pack_with_envelope(const process_header& head) {
  *  metadata to make sense of data as it is streamed.
  */
 
-template < typename Input, typename Output >
-taskset schedule(const char* doc, int len, int task_size)
+template < typename Input >
+taskset schedule(Input& in, const char* doc, int len, int task_size)
 noexcept (false) {
-    Input in;
     in.unpack(doc, doc + len);
     in.attributes = normalized_attributes(in);
     auto fetch = build(in);
@@ -535,10 +534,12 @@ taskset mkschedule(const char* doc, int len, int task_size) noexcept (false) {
 
     const std::string function = document.at("function");
     if (function == "slice") {
-        return schedule< slice_query, slice_task >(doc, len, task_size);
+        slice_query q;
+        return schedule(q, doc, len, task_size);
     }
     if (function == "curtain") {
-        return schedule< curtain_query, curtain_task > (doc, len, task_size);
+        curtain_query q;
+        return schedule(q, doc, len, task_size);
     }
     throw std::logic_error("No handler for function " + function);
 }

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -548,8 +548,9 @@ schedule_maker< curtain_query, curtain_task >::header(
     index.push_back(query.dim1s .size());
     index.push_back(mdims.back().size());
 
-    index.insert(index.end(), query.dim0s .begin(), query.dim0s .end());
-    index.insert(index.end(), query.dim1s .begin(), query.dim1s .end());
+    const auto& line_numbers = query.manifest.line_numbers;
+    for (auto x : query.dim0s) index.push_back(line_numbers[0][x]);
+    for (auto x : query.dim1s) index.push_back(line_numbers[1][x]);
     index.insert(index.end(), mdims.back().begin(), mdims.back().end());
 
     /*


### PR DESCRIPTION
Break up the scheduler_maker system into free overloaded functions. It
turns out that the generic algorithms can just as easily be written with
free templated functions, and the lookup rules through a class really
isn't used. Maybe shared-state-between-<type> will be useful at some
point in the future, but then that can rather be special-cased rather
than introducing heavy template machinery for the general case. This
benefit is a simplification.

All changes are really just in signatures; the schedule() and
partition() functions are free, and uses overloading to select the
correct build() and header() functions, rather than the class. Since the
selection was always derived only from the input- and output types then
there should be no real loss in flexibility.

The partition() and schedule() functions can still be considered
customisation points, but rather than having to go through the class it
is sufficient to provide a more-specific version.