### PR TITLE
Attributes in curtain

### DIFF
--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -302,7 +302,10 @@ func (c *cube) basicSlice(
 
 func (c *cube) CurtainByIndex(
 	ctx    context.Context,
-	args   struct { Coords [][]int32 `json:"coords"` },
+	args   struct {
+		Coords [][]int32
+		Opts   *opts
+	},
 ) (*promise, error) {
 	return c.basicCurtain(
 		ctx,
@@ -310,12 +313,16 @@ func (c *cube) CurtainByIndex(
 			Kind: "index",
 			Coords: args.Coords,
 		},
+		args.Opts,
 	)
 }
 
 func (c *cube) CurtainByLineno(
 	ctx    context.Context,
-	args   struct { Coords [][]int32 `json:"coords"` },
+	args   struct {
+		Coords [][]int32
+		Opts   *opts
+	},
 ) (*promise, error) {
 	return c.basicCurtain(
 		ctx,
@@ -323,12 +330,14 @@ func (c *cube) CurtainByLineno(
 			Kind: "lineno",
 			Coords: args.Coords,
 		},
+		args.Opts,
 	)
 }
 
 func (c *cube) basicCurtain(
 	ctx    context.Context,
 	args   curtainargs,
+	opts   *opts,
 ) (*promise, error) {
 	keys := ctx.Value("keys").(map[string]string)
 	pid  := keys["pid"]
@@ -348,6 +357,7 @@ func (c *cube) basicCurtain(
 		StorageEndpoint: c.root.endpoint,
 		Function:        "curtain",
 		Args:            args,
+		Opts:            opts,
 	}
 	query, err := c.root.sched.MakeQuery(&msg)
 	if err != nil {
@@ -409,8 +419,8 @@ type Cube {
 
     sliceByLineno(dim: Int!, lineno: Int!, opts: Opts): Promise
     sliceByIndex(dim: Int!, index: Int!, opts: Opts): Promise
-    curtainByLineno(coords: [[Int!]!]!): Promise
-    curtainByIndex(coords: [[Int!]!]!): Promise
+    curtainByLineno(coords: [[Int!]!]!, opts: Opts): Promise
+    curtainByIndex( coords: [[Int!]!]!, opts: Opts): Promise
 }
 	`
 	resolver := &resolver {

--- a/core/include/oneseismic/messages.hpp
+++ b/core/include/oneseismic/messages.hpp
@@ -278,11 +278,16 @@ struct curtain_bundle {
      * structure. This is a detail that partially comes from using a statically
      * typed language, but it makes for nice messages regardless.
      *
+     * The zlength is the height of the output in the z dimension; this is
+     * trace-length for data, and usually 1 for attributes. It's embedded in
+     * the message to make decoding easier, and to handle more shapes.
+     *
      * [1] conceptually, although multiple fragments may be merged
      * [2] this might get changed to multiple shorter arrays
      */
     std::string attr;
     int size;
+    int zlength;
     std::vector< int > major;
     std::vector< int > minor;
     std::vector< float > values;

--- a/core/src/decoder.cpp
+++ b/core/src/decoder.cpp
@@ -352,7 +352,7 @@ noexcept (false) {
 
 void decoder::curtain(const msgpack::v2::object& obj)
 noexcept (false) {
-    const auto& slots = astuple(obj, 5);
+    const auto& slots = astuple(obj, 6);
 
     const auto attribute = slots[0].as< std::string >();
     auto* dst = this->get_writer_for(attribute);
@@ -362,12 +362,12 @@ noexcept (false) {
     // TODO: check message integrity (array sizes)
     // TODO: cache vectors
     const auto size  = slots[1].as< int >();
-    const auto major = slots[2].as< std::vector< int > >();
-    const auto minor = slots[3].as< std::vector< int > >();
-    const auto v     = asbinarray(slots[4]);
+    const auto zlen  = slots[2].as< int >();
+    const auto major = slots[3].as< std::vector< int > >();
+    const auto minor = slots[4].as< std::vector< int > >();
+    const auto v     = asbinarray(slots[5]);
 
     const auto* src = v.ptr;
-    const auto zlen = this->head.index[2];
     for (int n = 0; n < size; ++n) {
         const auto ifst = major[n*2 + 0];
         const auto ilst = major[n*2 + 1];

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -135,9 +135,10 @@ std::string curtain_bundle::pack() const noexcept (false) {
     msgpack::sbuffer buffer;
     msgpack::packer< decltype(buffer) > packer(buffer);
 
-    packer.pack_array(5);
+    packer.pack_array(6);
     packer.pack(this->attr);
     packer.pack(size);
+    packer.pack(zlength);
     packer.pack(major);
     packer.pack(minor);
     packarray_bin(packer, this->values);
@@ -155,10 +156,11 @@ noexcept (false) {
 
     obj.via.array.ptr[0] >> this->attr;
     obj.via.array.ptr[1] >> this->size;
-    obj.via.array.ptr[2] >> this->major;
-    obj.via.array.ptr[3] >> this->minor;
+    obj.via.array.ptr[2] >> this->zlength;
+    obj.via.array.ptr[3] >> this->major;
+    obj.via.array.ptr[4] >> this->minor;
 
-    auto tv = obj.via.array.ptr[4];
+    auto tv = obj.via.array.ptr[5];
     if (tv.type != msgpack::v2::type::BIN)
         throw bad_value("curtain.values should be BIN");
     this->values.resize(tv.via.bin.size / sizeof(float));

--- a/core/src/messages.cpp
+++ b/core/src/messages.cpp
@@ -137,10 +137,10 @@ std::string curtain_bundle::pack() const noexcept (false) {
 
     packer.pack_array(6);
     packer.pack(this->attr);
-    packer.pack(size);
-    packer.pack(zlength);
-    packer.pack(major);
-    packer.pack(minor);
+    packer.pack(this->size);
+    packer.pack(this->zlength);
+    packer.pack(this->major);
+    packer.pack(this->minor);
     packarray_bin(packer, this->values);
     return std::string(buffer.data(), buffer.size());
 }

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -223,15 +223,15 @@ void curtain::init(const char* msg, int len) {
         return x.coordinates.size();
     };
 
-    this->output.attr = this->input.attribute;
-    this->output.size = ids.size();
-    this->output.major.reserve(this->output.size * 2);
-    this->output.minor.reserve(this->output.size * 2);
-    this->output.values.resize(this->traceindex.back());
     const auto zdim    = this->gvt.mkdim(gvt.ndims - 1);
     const auto zheight = this->gvt.fragment_shape()[zdim];
     const auto zmax    = this->gvt.nsamples(zdim);
+    this->output.attr = this->input.attribute;
+    this->output.size = ids.size();
     this->output.zlength = zmax;
+    this->output.major.reserve(this->output.size * 2);
+    this->output.minor.reserve(this->output.size * 2);
+    this->output.values.resize(this->traceindex.back());
     for (const auto& id : ids) {
         const auto zfst = id.id[zdim] * zheight;
         const auto zlst = std::min(zfst + zheight, zmax);

--- a/core/src/process.cpp
+++ b/core/src/process.cpp
@@ -231,6 +231,7 @@ void curtain::init(const char* msg, int len) {
     const auto zdim    = this->gvt.mkdim(gvt.ndims - 1);
     const auto zheight = this->gvt.fragment_shape()[zdim];
     const auto zmax    = this->gvt.nsamples(zdim);
+    this->output.zlength = zmax;
     for (const auto& id : ids) {
         const auto zfst = id.id[zdim] * zheight;
         const auto zlst = std::min(zfst + zheight, zmax);


### PR DESCRIPTION
# Include curtain attr-height in message

Include the height/zlength in the curtain message, rather than assuming
it can be read from the index. This makes the decoding function more
obviousy and immediate (since it no longer needs to read the index), but
bloats the message with another byte or two per bundle (which I think
is an acceptable trade off).

On its own this change only makes the decoding slightly simpler, but
this opens up for decoding curtain attributes of non-trace-length in the
z direction.

# Add attribute support in curtainBy queries 


Introduce the opts argument to the curtainBy* family of queries, and
support getting attributes along with data for the curtain query.

The implementation is pretty straight forward for the go bits; add opts
to the schema, and include the opts parameter in the message.Query.

The C++/query planning follows the pattern laid out by the attribute
support in slice, and with the exception of some repetetive code it
should not be too surprising; it is like when getting describing traces,
except tasks are not issued for the z-dimension.

This implements server-side support for attributes, but the attributes
are not made available in client code, since there is no good interface
support for it yet. Still, from my test setup I get this for emulating
a slice with the curtain query:

    <xarray.DataArray 'curtain' (x, y: 201, time: 850)>
    array([[0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           ...,
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.],
           [0., 0., 0., ..., 0., 0., 0.]], dtype=float32)
    Coordinates:
        inline     (x, y) int64 9961 9963 9965 9967 9969 ... 10355 10357 10359 10361
        crossline  (x, y) int64 2321 2321 2321 2321 2321 ... 2321 2321 2321 2321
      * time       (time) int64 0 4000 8000 12000 ... 3388000 3392000 3396000
        cdpx       (x, y) float32 9.566e+06 9.566e+06 ... 9.686e+06 9.687e+06
        cdpy       (x, y) float32 1.011e+07 1.011e+07 ... 1.059e+07 1.059e+07

