### PR TITLE
Fallthrough attributes; revert msgpack-with-cmake

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -45,8 +45,7 @@ target_include_directories(oneseismic
 if (BUILD_CORE)
     add_library(json INTERFACE)
     target_include_directories(json INTERFACE external/nlohmann)
-    find_package(fmt     REQUIRED)
-    find_package(msgpack REQUIRED)
+    find_package(fmt REQUIRED)
 
     target_sources(oneseismic
         PRIVATE
@@ -60,7 +59,6 @@ if (BUILD_CORE)
         PRIVATE
             include
             external/nlohmann
-            msgpackc-cxx
     )
     target_link_libraries(oneseismic
         PUBLIC

--- a/core/src/decoder.cpp
+++ b/core/src/decoder.cpp
@@ -243,7 +243,7 @@ decoder::status decoder::process() {
             }
             this->phase = state::header;
         }
-        /* INTENTIONAL FALL-THROUGH */
+        [[fallthrough]];
 
         case state::header:
             if (!this->unp.next(this->objhandle))
@@ -269,7 +269,7 @@ decoder::status decoder::process() {
             }
             this->phase = state::bundles;
         }
-        /* INTENTIONAL FALL-THROUGH */
+        [[fallthrough]];
 
         case state::bundles:
             while (this->nbundles > 0) {


### PR DESCRIPTION
Use C++17 fallthrough attribute instead of comment

--

Revert "Find and link msgpack with cmake"

This change is pretty broken, as it relies on newer versions of
libmsgpack [1], and was not thoroughly tested. It was doubly broken
since it did not actually link, but rather used the include-dir, and it
would not work for decoder-only builds.

Since we use the header-only feature relying on it being in an available
include path is good enough for now, although this bit of the makefiles
should probably be improved upon.

It was merged to make the macos CI build work again, but in this
particular broken instance the real fix was installing the msgpack-cxx
package; see commit 38487dc

[1] e.g. the target msgpackc-cxx is not found on my debian buster
    (which provides 3.0.1-3)