### PR TITLE
Split cgo scheduler and query engine

### DIFF
--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -30,7 +30,7 @@ type resolver struct {
 type cube struct {
 	id       graphql.ID
 	root     *resolver
-	manifest map[string]interface{}
+	manifest json.RawMessage
 }
 
 type promise struct {
@@ -91,16 +91,10 @@ func (r *resolver) Cube(
 		return nil, errors.New("Internal error")
 	}
 
-	manifest, err := manifestAsMap(doc)
-	if err != nil {
-		log.Printf("pid=%s %v", pid, err)
-		return nil, err
-	}
-
 	return &cube {
 		id:       args.Id,
 		root:     r,
-		manifest: manifest,
+		manifest: doc,
 	}, nil
 }
 
@@ -152,11 +146,6 @@ func getManifest(
 		return nil, err
 	}
 	return manifest, nil
-}
-
-func manifestAsMap(doc []byte) (m map[string]interface{}, err error) {
-	err = json.Unmarshal(doc, &m)
-	return
 }
 
 type sliceargs struct {

--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -85,6 +85,12 @@ func (r *resolver) Cube(
 		return nil, err
 	}
 
+	err = keys["session"].(*QuerySession).InitWithManifest(doc)
+	if err != nil {
+		log.Printf("pid=%s, %v", pid, err)
+		return nil, errors.New("Internal error")
+	}
+
 	manifest, err := manifestAsMap(doc)
 	if err != nil {
 		log.Printf("pid=%s %v", pid, err)

--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -67,15 +67,15 @@ func (r *resolver) Cube(
 	ctx context.Context,
 	args struct { Id graphql.ID },
 ) (*cube, error) {
-	keys := ctx.Value("keys").(map[string]string)
-	pid  := keys["pid"]
-	auth := keys["Authorization"]
+	keys := ctx.Value("keys").(map[string]interface{})
+	pid  := keys["pid"].(string)
+	auth := keys["Authorization"].(string)
 
 	creds := credentials(auth)
 	doc, err := getManifest(
 		ctx,
 		creds,
-		keys["url-query"],
+		keys["url-query"].(string),
 		r.endpoint,
 		string(args.Id),
 	)
@@ -137,8 +137,8 @@ func asSliceSliceInt32(root interface{}) ([][]int32, error) {
 func (c *cube) Linenumbers(ctx context.Context) ([][]int32, error) {
 	doc, ok := c.manifest["line-numbers"]
 	if !ok {
-		keys := ctx.Value("keys").(map[string]string)
-		pid  := keys["pid"]
+		keys := ctx.Value("keys").(map[string]interface{})
+		pid  := keys["pid"].(string)
 		log.Printf(
 			"pid=%s %s/manifest.json broken; no dimensions",
 			pid,
@@ -247,12 +247,12 @@ func (c *cube) basicSlice(
 	args sliceargs,
 	opts *opts,
 ) (*promise, error) {
-	keys := ctx.Value("keys").(map[string]string)
-	pid  := keys["pid"]
+	keys := ctx.Value("keys").(map[string]interface{})
+	pid  := keys["pid"].(string)
 	msg := message.Query {
 		Pid:             pid,
-		Token:           keys["Authorization"],
-		UrlQuery:        keys["url-query"],
+		Token:           keys["Authorization"].(string),
+		UrlQuery:        keys["url-query"].(string),
 		Guid:            string(c.id),
 		Manifest:        c.manifest,
 		StorageEndpoint: c.root.endpoint,
@@ -329,12 +329,12 @@ func (c *cube) basicCurtain(
 	args   curtainargs,
 	opts   *opts,
 ) (*promise, error) {
-	keys := ctx.Value("keys").(map[string]string)
-	pid  := keys["pid"]
+	keys := ctx.Value("keys").(map[string]interface{})
+	pid  := keys["pid"].(string)
 	msg := message.Query {
 		Pid:             pid,
-		Token:           keys["Authorization"],
-		UrlQuery:        keys["url-query"],
+		Token:           keys["Authorization"].(string),
+		UrlQuery:        keys["url-query"].(string),
 		Guid:            string(c.id),
 		Manifest:        c.manifest,
 		StorageEndpoint: c.root.endpoint,
@@ -505,7 +505,7 @@ func (g *gql) execQuery(
 	opName string,
 	variables map[string]interface{},
 ) *graphql.Response {
-	keys := map[string]string {
+	keys := map[string]interface{} {
 		"pid": ctx.GetString("pid"),
 		"Authorization": ctx.GetHeader("Authorization"),
 		"url-query": ctx.Request.URL.RawQuery,

--- a/api/api/graphql.go
+++ b/api/api/graphql.go
@@ -25,6 +25,7 @@ type gql struct {
 
 type resolver struct {
 	BasicEndpoint
+	QueryEngine
 }
 type cube struct {
 	id       graphql.ID
@@ -259,7 +260,7 @@ func (c *cube) basicSlice(
 		Args:            args,
 		Opts:            opts,
 	}
-	query, err := c.root.sched.MakeQuery(&msg)
+	query, err := c.root.PlanQuery(&msg)
 	if err != nil {
 		log.Printf("pid=%s, %v", pid, err)
 		return nil, nil
@@ -341,7 +342,7 @@ func (c *cube) basicCurtain(
 		Args:            args,
 		Opts:            opts,
 	}
-	query, err := c.root.sched.MakeQuery(&msg)
+	query, err := c.root.PlanQuery(&msg)
 	if err != nil {
 		log.Printf("pid=%s, %v", pid, err)
 		return nil, nil
@@ -410,6 +411,9 @@ type Cube {
 			endpoint,
 			storage,
 		),
+		QueryEngine {
+			tasksize: 10,
+		},
 	}
 
 

--- a/api/api/query.cpp
+++ b/api/api/query.cpp
@@ -1,4 +1,4 @@
-#include "scheduler.h"
+#include "query.h"
 
 #include <algorithm>
 #include <cassert>

--- a/api/api/query.cpp
+++ b/api/api/query.cpp
@@ -16,7 +16,6 @@ plan mkschedule(const char* doc, int len, int task_size) try {
     }
 
     plan p {};
-    p.status_code = 200;
     p.len = taskset.count();
     p.tasks = new char[taskset.size()];
     p.sizes = new int [p.len];
@@ -25,7 +24,6 @@ plan mkschedule(const char* doc, int len, int task_size) try {
     return p;
 } catch (std::exception& e) {
     plan p {};
-    p.status_code = 500;
     auto* err = new char[std::strlen(e.what()) + 1];
     std::strcpy(err, e.what());
     p.err = err;

--- a/api/api/query.cpp
+++ b/api/api/query.cpp
@@ -11,13 +11,21 @@
 
 #include <oneseismic/plan.hpp>
 
-void cleanup(plan* p) {
+void plan_delete(plan* p) {
     if (!p) return;
 
     delete[] p->err;
     delete[] p->sizes;
     delete[] p->tasks;
     *p = plan {};
+}
+
+void query_result_delete(query_result* p) {
+    if (!p) return;
+
+    delete[] p->err;
+    delete[] p->body;
+    *p = query_result {};
 }
 
 struct session : public one::session {};
@@ -62,4 +70,21 @@ try {
     std::strcpy(err, e.what());
     p.err = err;
     return p;
+}
+
+query_result session_query_manifest(session* self, const char* path, int len) {
+    try {
+        const auto paths = std::string(path, len);
+        const auto result = self->query_manifest(paths);
+        query_result r {};
+        r.body = new char[result.size()];
+        r.size = result.size();
+        std::copy_n(result.begin(), r.size, r.body);
+        return r;
+    } catch (std::exception& e) {
+        query_result r {};
+        r.err = new char[std::strlen(e.what()) + 1];
+        std::strcpy(r.err, e.what());
+        return r;
+    }
 }

--- a/api/api/query.go
+++ b/api/api/query.go
@@ -1,0 +1,70 @@
+package api
+
+// #cgo LDFLAGS: -loneseismic
+// #include <stdlib.h>
+// #include "query.h"
+import "C"
+import "unsafe"
+
+import (
+	"fmt"
+
+	"github.com/equinor/oneseismic/api/internal/message"
+)
+
+type QueryPlan struct {
+	header []byte
+	plan   [][]byte
+}
+
+type QueryError struct {
+	msg    string
+}
+
+func (qe *QueryError) Error() string {
+	return qe.msg
+}
+
+/*
+ * The Query Engine struct, which mostly just wraps the C++ functionality and
+ * gives it a go interface. This makes an "executable plan" (set of job
+ * descriptions) from a query, e.g. sliceByIndex.
+ */
+type QueryEngine struct {
+	tasksize int
+}
+
+func (qe *QueryEngine) PlanQuery(query *message.Query) (*QueryPlan, error) {
+	msg, err := query.Pack()
+	if err != nil {
+		return nil, fmt.Errorf("pack error: %w", err)
+	}
+	// TODO: exhaustive error check including those from C++ exceptions
+	csched := C.mkschedule(
+		(*C.char)(unsafe.Pointer(&msg[0])),
+		C.int(len(msg)),
+		C.int(qe.tasksize),
+	)
+	defer C.cleanup(&csched)
+	if csched.err != nil {
+		return nil, &QueryError {
+			msg: C.GoString(csched.err),
+		}
+	}
+
+	ntasks := int(csched.len)
+	result := make([][]byte, 0, ntasks)
+	sizes  := (*[1 << 30]C.int)(unsafe.Pointer(csched.sizes))[:ntasks:ntasks]
+
+	this := uintptr(unsafe.Pointer(csched.tasks))
+	for _, size := range sizes {
+		result = append(result, C.GoBytes(unsafe.Pointer(this), size))
+		this += uintptr(size)
+	}
+
+	headerindex := len(result) - 1
+	return &QueryPlan {
+		header: result[headerindex],
+		plan:   result[:headerindex],
+	}, nil
+}

--- a/api/api/query.h
+++ b/api/api/query.h
@@ -11,21 +11,6 @@ struct plan {
      * is the only correct way to determine if the function succeeded or not.
      */
     const char* err;
-    /*
-     * HTTP status code hint. This is really only meaningful when err is not
-     * null, in order to return a more accurate status code to the caller.
-     *
-     * The status code should be considered a hint, and not definite - if the
-     * scheduler/query planner has more information, it is free to not respect
-     * the status_code here.
-     *
-     * The status_code may not always be set, even if err is not null, and
-     * callers should have a fallback path should this be zero or an invalid
-     * HTTP status code.
-     *
-     * If the status code is not explicitly set, it defaults to zero.
-     */
-    int status_code;
 
     /*
      * The number of task groups/chunks in this plan, including the header.

--- a/api/api/query.h
+++ b/api/api/query.h
@@ -35,8 +35,16 @@ struct plan {
     char* tasks;
 };
 
-struct plan mkschedule(const char* doc, int len, int task_size);
 void cleanup(struct plan*);
+
+struct session;
+struct session* session_new();
+const char* session_init(struct session*, const char* doc, int len);
+struct plan session_plan_query(
+    struct session*,
+    const char* doc,
+    int len,
+    int task_size);
 
 #ifdef __cplusplus
 }

--- a/api/api/query.h
+++ b/api/api/query.h
@@ -1,5 +1,5 @@
-#ifndef ONESEISMIC_CGO_SLICE_H
-#define ONESEISMIC_CGO_SLICE_H
+#ifndef ONESEISMIC_CGO_QUERY_H
+#define ONESEISMIC_CGO_QUERY_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,4 +56,4 @@ void cleanup(struct plan*);
 #ifdef __cplusplus
 }
 #endif //__cplusplus
-#endif //ONESEISMIC_CGO_SLICE_H
+#endif //ONESEISMIC_CGO_QUERY_H

--- a/api/api/query.h
+++ b/api/api/query.h
@@ -35,7 +35,18 @@ struct plan {
     char* tasks;
 };
 
-void cleanup(struct plan*);
+struct query_result {
+    char* err;
+    /*
+     * The body is the already json-encoded response. Accessing this if err is
+     * set is undefined behaviour.
+     */
+    char* body;
+    int size;
+};
+
+void plan_delete(struct plan*);
+void query_result_delete(struct query_result*);
 
 struct session;
 struct session* session_new();
@@ -45,6 +56,11 @@ struct plan session_plan_query(
     const char* doc,
     int len,
     int task_size);
+
+struct query_result session_query_manifest(
+    struct session*,
+    const char* path,
+    int len);
 
 #ifdef __cplusplus
 }

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -16,15 +16,15 @@ type Message interface {
  * authorization etc. into a single message.
  */
 type Query struct {
-	Pid             string       `json:"pid"`
-	Token           string       `json:"token"`
-	UrlQuery        string       `json:"url-query"`
-	Guid            string       `json:"guid"`
+	Pid             string          `json:"pid"`
+	Token           string          `json:"token"`
+	UrlQuery        string          `json:"url-query"`
+	Guid            string          `json:"guid"`
 	Manifest        json.RawMessage `json:"manifest"`
-	StorageEndpoint string       `json:"storage_endpoint"`
-	Function        string       `json:"function"`
-	Args            interface {} `json:"args"`
-	Opts            interface {} `json:"opts"`
+	StorageEndpoint string          `json:"storage_endpoint"`
+	Function        string          `json:"function"`
+	Args            interface {}    `json:"args"`
+	Opts            interface {}    `json:"opts"`
 }
 
 func (msg *Query) Pack() ([]byte, error) {

--- a/api/internal/message/message.go
+++ b/api/internal/message/message.go
@@ -20,7 +20,7 @@ type Query struct {
 	Token           string       `json:"token"`
 	UrlQuery        string       `json:"url-query"`
 	Guid            string       `json:"guid"`
-	Manifest        interface {} `json:"manifest"`
+	Manifest        json.RawMessage `json:"manifest"`
 	StorageEndpoint string       `json:"storage_endpoint"`
 	Function        string       `json:"function"`
 	Args            interface {} `json:"args"`

--- a/core/include/oneseismic/plan.hpp
+++ b/core/include/oneseismic/plan.hpp
@@ -56,6 +56,8 @@ public:
         int task_size)
     noexcept (false);
 
+    std::string query_manifest(const std::string& path) noexcept (false);
+
 private:
     class impl;
     std::unique_ptr< impl > self;

--- a/core/include/oneseismic/plan.hpp
+++ b/core/include/oneseismic/plan.hpp
@@ -2,6 +2,7 @@
 #define ONESEISMIC_PLAN_HPP
 
 #include <exception>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -40,7 +41,25 @@ struct taskset {
     }
 };
 
-taskset mkschedule( const char* doc, int len, int task_size) noexcept (false);
+class session {
+public:
+    session();
+    session(session&&);
+    session(const session&) = delete;
+    session& operator = (session&&);
+    ~session();
+
+    void init(const char* doc, int len) noexcept (false);
+    taskset plan_query(
+        const char* doc,
+        int len,
+        int task_size)
+    noexcept (false);
+
+private:
+    class impl;
+    std::unique_ptr< impl > self;
+};
 
 }
 

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -611,12 +611,23 @@ noexcept (false) {
     throw std::logic_error("No handler for function " + function);
 }
 
+std::string session::impl::query_manifest(const std::string& path)
+noexcept (false) {
+    nlohmann::json::json_pointer ptr(path);
+    return this->manifest[ptr].dump();
+}
+
 void session::init(const char* doc, int len) noexcept (false) {
     self->init(doc, len);
 }
 
 taskset session::plan_query(const char* doc, int len, int task_size) {
     return self->plan_query(doc, len, task_size);
+}
+
+std::string session::query_manifest(const std::string& path)
+noexcept (false) {
+    return self->query_manifest(path);
 }
 
 }

--- a/core/src/plan.cpp
+++ b/core/src/plan.cpp
@@ -553,7 +553,35 @@ noexcept (false) {
 
 }
 
-taskset mkschedule(const char* doc, int len, int task_size) noexcept (false) {
+class session::impl {
+public:
+    void init(const char* doc, int len) noexcept (false);
+    taskset plan_query(
+        const char* doc,
+        int len,
+        int task_size)
+    noexcept (false);
+
+    std::string query_manifest(const std::string& path) noexcept (false);
+
+private:
+    nlohmann::json manifest;
+};
+
+session::session() : self(std::make_unique<impl>()) {}
+session::session(session&&) = default;
+session& session::operator = (session&&) = default;
+session::~session() = default;
+
+void session::impl::init(const char* doc, int len) noexcept (false) {
+    this->manifest = nlohmann::json::parse(doc, doc + len);
+}
+
+taskset session::impl::plan_query(
+    const char* doc,
+    int len,
+    int task_size)
+noexcept (false) {
     const auto document = nlohmann::json::parse(doc, doc + len);
     /*
      * Right now, only format-version: 1 is supported, but checking the format
@@ -581,6 +609,14 @@ taskset mkschedule(const char* doc, int len, int task_size) noexcept (false) {
         return schedule(q, doc, len, task_size);
     }
     throw std::logic_error("No handler for function " + function);
+}
+
+void session::init(const char* doc, int len) noexcept (false) {
+    self->init(doc, len);
+}
+
+taskset session::plan_query(const char* doc, int len, int task_size) {
+    return self->plan_query(doc, len, task_size);
 }
 
 }


### PR DESCRIPTION
This is one of those weird PRs that do very little, but prepare very much.

# Splitting up scheduler
The scheduler has been split up into its scheduler (I/O) part and its query engine (C++) parts, and except for the move-and-rename, the scheduling stuff is not really changed anything.

# Introducing query engine and sessions
The term "query engine" is introduced, to take over the responsibilities of the mkschedule() C++ entry point. It is an improved model of the real responsibilities, namely planning and possibly optimising query plans before they're executed. I'm honestly still not 100% sold on the name, but it is an improvement over the old nonsense.

The query engine does all its real work in C++, and go serves mostly to integrate it with the graphql resolvers and to feed it data. The sessions opens up for reusing buffers and state even between queries, although it is a hard assumption that 1 query (i.e. cube and "down") means 1 session.

# The bad
This introduces a bit more C++ and a bunch of cgo, which does increase the barrier of entry. It's (probably) still valuable as it means fewer moving parts and focuses all work in C++, but it does come at a cost.