### PR TITLE
Add javascript support library

### DIFF
--- a/javascript/CMakeLists.txt
+++ b/javascript/CMakeLists.txt
@@ -1,0 +1,26 @@
+project (oneseismic-javascript LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.13)
+
+find_package(oneseismic REQUIRED)
+
+option(ONESEISMIC_ASMJS_ONLY "Target asm.js (no WebAssembly)"        OFF)
+option(ONESEISMIC_MODULARIZE "Modularize module; useful for node.js" OFF)
+
+add_executable(oneseismic decoder.cpp)
+target_link_libraries  (oneseismic PRIVATE oneseismic::oneseismic)
+target_compile_features(oneseismic PRIVATE cxx_std_17)
+target_link_options    (oneseismic
+    PRIVATE
+        --bind
+        --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/decoding.js
+)
+
+if (ONESEISMIC_MODULARIZE)
+    target_link_options(oneseismic PRIVATE "SHELL:-s MODULARIZE=1")
+endif ()
+
+if (ONESEISMIC_ASMJS_ONLY)
+    target_link_options(oneseismic PRIVATE "SHELL:-s WASM=0")
+else ()
+    target_link_options(oneseismic PRIVATE "SHELL:-s WASM=1")
+endif ()

--- a/javascript/LICENSE
+++ b/javascript/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,0 +1,36 @@
+Building the javascript library can be daunting
+
+# Using Docker
+The easiest way to get started, and probably easiest to automate for packaging
+purposes, is to build using docker.
+
+Upstream publish the emscripten/emsdk image, but that image does not include
+msgpack. You can build a custom image with msgpack included using the
+emscripten.dockerfile
+
+    cd javascript/
+    docker build -f emscripten.dockerfile -t oneseismic/emscripten
+
+Then, in order to build, run the build.sh in the docker container. Since it
+needs the core/ directory it must be run from the oneseismic root:
+
+    docker run --rm -v $(pwd):/src -u $(id -u):$(id -g) \
+        oneseismic/emscripten javascript/build.sh /src/js
+
+The options set in build.sh are not authorative, but a very good starting
+point.
+
+# Using system emscripten + cmake
+If you already have emscripten installed on your system, you can run build.sh
+(or manually run the commands in it) directly. Please note that emscripten does
+not like system installed headers, so msgpack (the only real dependency) should
+be available at some non-system path and explicitly included with
+`-DCMAKE_CXX_FLAGS=-Ipath/msgpack`
+
+# Demos
+There are a couple of demos on how to use the oneseismic decoder from
+javascript in the demo/ directory - one for node.js, and one for vanilla
+browser javascript.
+
+Please note that you libraries probably should be built modularized for
+node.js.

--- a/javascript/build.sh
+++ b/javascript/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -xe
+
+BUILD_DIR="$1"
+
+emcmake cmake \
+    -S core/ -B $BUILD_DIR/core/ \
+    -DBUILD_CORE=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS=-I/msgpack \
+    -DCMAKE_TOOLCHAIN_FILE=/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
+
+pushd $BUILD_DIR/core
+emmake make
+popd
+
+emcmake cmake \
+    -S javascript/ -B $BUILD_DIR/javascript/ \
+    -Doneseismic_DIR=$BUILD_DIR/core/ \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS=-I/msgpack \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=1 \
+    -DCMAKE_TOOLCHAIN_FILE=/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
+
+pushd $BUILD_DIR/javascript
+emmake make
+popd

--- a/javascript/decoder.cpp
+++ b/javascript/decoder.cpp
@@ -1,0 +1,69 @@
+#include <string>
+#include <vector>
+
+#include <oneseismic/decoder.hpp>
+
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+
+void register_writer(
+    one::decoder& self,
+    const std::string& key,
+    std::uintptr_t ptr)
+{
+    self.register_writer(key, reinterpret_cast< void* >(ptr));
+}
+
+void buffer(one::decoder& self, const std::string& buffer) {
+    return self.buffer(buffer.data(), buffer.size());
+}
+
+one::decoder::status
+buffer_and_process(one::decoder& self, const std::string& buffer) {
+    return self.buffer_and_process(buffer.data(), buffer.size());
+}
+
+bool header_ready(const one::decoder& self) {
+    return self.header();
+}
+
+one::process_header header_get(const one::decoder& self) {
+    return *self.header();
+}
+
+EMSCRIPTEN_BINDINGS(decoder) {
+    register_vector< int >("VectorInt");
+    register_vector< std::string >("VectorString");
+
+    class_< one::process_header >("process_header")
+        .property("attrs",    &one::process_header::attributes)
+        .property("ndims",    &one::process_header::ndims)
+        .property("index",    &one::process_header::index)
+        .property("function", &one::process_header::function)
+        .property("shapes",   &one::process_header::shapes)
+        .property("labels",   &one::process_header::labels)
+    ;
+
+    class_< one::decoder >("decoder")
+        .constructor<>()
+        .function("reset",               &one::decoder::reset)
+        .function("process",             &one::decoder::process)
+        .function("buffer",              buffer)
+        .function("buffer_and_process",  buffer_and_process)
+        .function("header_ready",        header_ready)
+        .function("header_get",          header_get)
+        .function("register_writer",     register_writer)
+    ;
+
+    using status = one::decoder::status;
+    enum_<status>("status")
+        .value("paused", status::paused)
+        .value("done",   status::done)
+    ;
+
+    enum_<one::functionid>("functionid")
+        .value("slice",   one::functionid::slice)
+        .value("curtain", one::functionid::curtain)
+    ;
+}

--- a/javascript/decoding.js
+++ b/javascript/decoding.js
@@ -1,0 +1,100 @@
+function f32Array(size) {
+    const offset = Module._malloc(size * 4);
+    Module.HEAPF32.set(new Float32Array(size), offset / 4);
+    return {
+        "data": Module.HEAPF32.subarray(offset / 4, offset / 4 + size),
+        "offset": offset
+    }
+}
+
+function splitshapes(shapes) {
+    /*
+     * This function is a bit awkward, but unpacks the tuples
+     *     [3 201 720 1 2 20 15] => [[201 720 1], [20, 15]]
+     * for all the attributes in the response
+     */
+    let i = 0
+    const xs = new Array()
+    while (i < shapes.length) {
+        const n = shapes[i];
+        i += 1;
+        xs.push(shapes.slice(i, i + n));
+        i += n;
+    }
+    return xs;
+}
+
+function emvector_to_array(xs) {
+    return new Array(xs.size()).fill(0).map((_, id) => xs.get(id))
+}
+
+function native_process_header(primitive) {
+    /*
+     * Using the C++-backed process-header is pretty awkward, since arrays
+     * aren't really arrays (they're embind VectorInt etc). Convert into a
+     * js-native object.
+     */
+    const head = {}
+    head.attrs    = emvector_to_array(primitive.attrs)
+    head.index    = emvector_to_array(primitive.index)
+    head.shapes   = emvector_to_array(primitive.shapes)
+    head.labels   = emvector_to_array(primitive.labels)
+    head.ndims    = primitive.ndims
+    head.function = primitive.function
+    return head
+}
+
+Module.stream_decoder = function() {
+    // TODO: maybe this should make an object proper, rather than just a very
+    // stateful function
+    const decoder = new Module.decoder()
+    decoder.reset();
+    const d = {};
+    let header = null;
+    let done = false;
+
+    return (chunk) => {
+        if (done) {
+            return [header, d];
+        }
+
+        if (chunk) {
+            decoder.buffer(chunk);
+        }
+
+        const ok = decoder.process();
+        if (ok === Module.status.done) {
+            // TODO: This delete must be guarded so it always runs; otherwise
+            // it will leak on errors or incomplete decoding
+            decoder.delete();
+            done = true;
+            return [header, d];
+        }
+
+        if (header === null) {
+            // not enough bytes to read the header - suspend and wait for more 
+            if (!decoder.header_ready()) {
+                return null;
+            }
+
+            const cppheader = decoder.header_get();
+            header = native_process_header(cppheader);
+            cppheader.delete()
+            const shapes = splitshapes(header.shapes);
+            const attrs  = header.attrs;
+            /*
+             * allocate arrays and give to the decoder. When process returns
+             * done(), all data has been read and is available in the d dict
+             */
+            for (let i = 0; i < shapes.length; i++) {
+                const attr  = attrs[i];
+                const shape = shapes[i];
+                const fdata = f32Array(shape.reduce((acc, v) => acc * v));
+                decoder.register_writer(attr, fdata.offset);
+                d[attr] = { shape: shape, data: fdata.data };
+            }
+        }
+
+        return [header, d];
+    };
+}

--- a/javascript/demo/demo-node.js
+++ b/javascript/demo/demo-node.js
@@ -1,0 +1,20 @@
+const one = require('oneseismic')
+const http = require('http')
+
+one().then(mod => {
+    http.get("http://host:port/result/<pid>/stream", {
+            headers: {
+                'Authorization': 'Bearer <token>'
+            }
+        }, (res) => {
+            dec = mod.decode_stream()
+            res.on('data', dec)
+            res.on('end', () => dec(null));
+        }).then(d => {
+            let data = d[1]
+            let vals = data['data']['data']
+            let sum = vals.reduce((acc, v) => acc + v);
+            console.log(sum);
+        })
+    })
+;

--- a/javascript/demo/demo.html
+++ b/javascript/demo/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <script>
+    var Module = {
+      onRuntimeInitialized: function() {
+          fetch("http://host:port/result/<pid>/stream", {
+              headers: {
+                  'Authorization': 'Bearer <token>'
+              }
+         })
+        .then(response => response.arrayBuffer())
+        .then(function (chunk) {
+              console.log(chunk);
+              let dec = Module.stream_decoder();
+              var x = dec(chunk);
+              x = dec(null);
+              const a = x[1]['data']['data'];
+              console.log(a.reduce((acc, v) => acc +v ));
+        })
+      }
+    };
+  </script>
+  <script src="oneseismic.js"></script>
+</html>
+

--- a/javascript/emscripten.dockerfile
+++ b/javascript/emscripten.dockerfile
@@ -1,0 +1,10 @@
+FROM emscripten/emsdk AS build_image
+
+RUN apt-get -qq -y update \
+    && DEBIAN_FRONTEND="noninteractive" \
+       apt-get -qq install -y --no-install-recommends \
+            libmsgpack-dev
+
+FROM emscripten/emsdk AS final_image
+COPY --from=build_image /usr/include/msgpack.* /msgpack/
+COPY --from=build_image /usr/include/msgpack/  /msgpack/msgpack/


### PR DESCRIPTION
Provide a javascript library for decoding oneseismic results. The
library itself is mostly the decoder compiled with emscripten, a little
bit of binding code, and some usability features. Please be aware that
the module itself is quite rough and needs a lot of love and testing.
Error paths in particular are not checked exhaustively (if at all).

Using oneseismic through the web browser (or even some other js runtime
like node) will be common, and native javascript decoding makes
client-side rendering fast and feasible.

With the library comes a couple of build scripts - driving the build
with cmake is quite painless, and the emscripten.dockerfile makes it
possible to run even without installing the emscripten sdk directly on
the host.

No testing hooks or testing strategy is included in the build scripts,
nor any deployment. I have yet to figure out how to distribute the
library, only how to build it.

The library can target both webassembly and "pure" js (asm.js), which is
easily controllable from the cmake file.

Like the python code, the javascript library is LGPL licenced - this
includes the decoder itself, even though the decoder is in the core/
tree.