### PR TITLE
Compile js decoder with ALLOW_MEMORY_GROWTH=1

### DIFF
--- a/javascript/CMakeLists.txt
+++ b/javascript/CMakeLists.txt
@@ -12,6 +12,7 @@ target_compile_features(oneseismic PRIVATE cxx_std_17)
 target_link_options    (oneseismic
     PRIVATE
         --bind
+	-s ALLOW_MEMORY_GROWTH=1
         --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/decoding.js
 )
 


### PR DESCRIPTION
Allows the javascript decoder to grow memory on demand. Without this
flag memory was running out even for rather small slices (~13MB).