### PR TITLE
Increase default worker download-pool-size to 30

### DIFF
--- a/api/cmd/fetch/main.go
+++ b/api/cmd/fetch/main.go
@@ -66,8 +66,8 @@ func parseopts() opts {
 	jobs := getopt.IntLong(
 		"jobs",
 		'j',
-		10,
-		"Allow N concurrent connections at once. Defaults to 10",
+		30,
+		"Allow N concurrent connections at once. Defaults to 30",
 		"N",
 	)
 	retries := getopt.IntLong(


### PR DESCRIPTION
The value 30 was derived experimentally. I wrote a tiny program that
fetched 1000 blobs (1M each) from the blob store, continously increasing
the worker pool size.

    1000 fetched with 1 workers in 13.948593307s
    1000 fetched with 2 workers in 6.811524751s
    1000 fetched with 3 workers in 4.705476097s
    1000 fetched with 4 workers in 3.626282842s
    1000 fetched with 5 workers in 2.953699548s
    1000 fetched with 6 workers in 2.642165633s
    1000 fetched with 7 workers in 2.338858917s
    1000 fetched with 8 workers in 2.080797274s
    1000 fetched with 9 workers in 1.973233638s
    1000 fetched with 10 workers in 1.898599639s
    1000 fetched with 11 workers in 1.827104382s
    1000 fetched with 12 workers in 1.73368034s
    1000 fetched with 13 workers in 1.702463758s
    1000 fetched with 14 workers in 1.714636046s
    1000 fetched with 15 workers in 1.841004657s
    1000 fetched with 16 workers in 1.690634554s
    1000 fetched with 17 workers in 2.277477051s
    1000 fetched with 18 workers in 1.652542372s
    1000 fetched with 19 workers in 1.695501339s

I could not really observe an improvement past ~23 workers, which means a
default worker pool size of 30 should generally max out throughput. A
worker pool slightly larger than the worker "soft cap" reduces penalty
for having a couple of idle or blocked workers somewhere in the
pipeline.