### PR TITLE
Setup update

### DIFF
--- a/api/cmd/query/main.go
+++ b/api/cmd/query/main.go
@@ -18,6 +18,7 @@ type opts struct {
 	storageURL   string
 	redisURL     string
 	signkey      string
+	port         string
 }
 
 func parseopts() opts {
@@ -56,6 +57,13 @@ func parseopts() opts {
 		0,
 		"Signing key used for response authorization tokens",
 		"key",
+	)
+	opts.port = "8080"
+	getopt.FlagLong(
+		&opts.port,
+		"port",
+		0,
+		"Port to start server on. Defaults to 8080",
 	)
 
 	getopt.Parse()
@@ -140,5 +148,5 @@ func main() {
 	graphql.POST("", gql.Post)
 
 	app.GET("/config", cfg.Get)
-	app.Run(":8080")
+	app.Run(fmt.Sprintf(":%s", opts.port))
 }

--- a/api/cmd/query/main.go
+++ b/api/cmd/query/main.go
@@ -17,7 +17,6 @@ type opts struct {
 	clientID     string
 	storageURL   string
 	redisURL     string
-	bind         string
 	signkey      string
 }
 
@@ -50,13 +49,6 @@ func parseopts() opts {
 		0,
 		"Redis URL",
 		"url",
-	)
-	getopt.FlagLong(
-		&opts.bind,
-		"bind",
-		0,
-		"Bind URL e.g. tcp://*:port",
-		"addr",
 	)
 	getopt.FlagLong(
 		&opts.signkey,

--- a/api/cmd/result/main.go
+++ b/api/cmd/result/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"time"
+	"fmt"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis/v8"
@@ -16,6 +17,7 @@ import (
 type opts struct {
 	broker  string
 	signkey string
+	port    string
 }
 
 func parseopts() opts {
@@ -40,6 +42,14 @@ func parseopts() opts {
 		0,
 		"Message broker (redis) URL",
 		"url",
+	)
+
+	opts.port = "8080"
+	getopt.FlagLong(
+		&opts.port,
+		"port",
+		0,
+		"Port to start server on. Defaults to 8080",
 	)
 
 	getopt.Parse()
@@ -71,5 +81,5 @@ func main() {
 	results.GET("/:pid", result.Get)
 	results.GET("/:pid/stream", result.Stream)
 	results.GET("/:pid/status", result.Status)
-	app.Run(":8080")
+	app.Run(fmt.Sprintf(":%s", opts.port))
 }

--- a/javascript/demo/demo-node.js
+++ b/javascript/demo/demo-node.js
@@ -1,20 +1,81 @@
-const one = require('oneseismic')
-const http = require('http')
+const one = require("oneseismic");
+const https = require("https");
 
-one().then(mod => {
-    http.get("http://host:port/result/<pid>/stream", {
+/**
+ * To run this demo:
+ *   1. Build the oneseismic library in module mode (aka ONESEISMIC_MODULARIZE=ON)
+ *   2. Let node environment know where to find it (export NODE_PATH=path_to_dir)
+ *   3. Update server, guid and sas_token.
+ *      For demo purpose container must be small and result is expected immediately
+ *      Exchange https with http in "require" if necessary
+ */
+
+one().then((mod) => {
+  server = "<oneseismic-endpoint>";
+  guid = "<guid>";
+  sas_token = "<sas_token>";
+
+  url = `${server}/graphql?${sas_token}`;
+  const query = `{ cube (id: "${guid}") { sliceByIndex(dim: 0, index: 0) } }`;
+
+  const req = https.request(
+    url,
+    {
+      method: "post",
+      headers: {
+        "Content-type": "application/json",
+      },
+    },
+    (res) => {
+      const { statusCode } = res;
+      if (statusCode !== 200) {
+        console.error("Request Failed.\n" + `Status Code: ${statusCode}`);
+        res.resume();
+        return;
+      }
+      res.on("data", async function (chunk) {
+        console.log("Got a response from query endpoint!");
+        promise = JSON.parse(chunk).data.cube.sliceByIndex;
+        https.get(
+          `${server}/${promise.url}/stream`,
+          {
             headers: {
-                'Authorization': 'Bearer <token>'
+              Authorization: `Bearer ${promise.key}`,
+            },
+          },
+          (res) => {
+            const { statusCode } = res;
+            if (statusCode !== 200) {
+              console.error("Request Failed.\n" + `Status Code: ${statusCode}`);
+              res.resume();
+              return;
             }
-        }, (res) => {
-            dec = mod.decode_stream()
-            res.on('data', dec)
-            res.on('end', () => dec(null));
-        }).then(d => {
-            let data = d[1]
-            let vals = data['data']['data']
-            let sum = vals.reduce((acc, v) => acc + v);
-            console.log(sum);
-        })
+            dec = mod.stream_decoder();
+            res.on("data", function (chunk) {
+              console.log("Got a chunk!");
+              var d = dec(chunk);
+              d = dec(null);
+              let data = d[1];
+              let vals = data["data"]["data"];
+              let sum = vals.reduce((acc, v) => acc + v);
+              console.log(sum);
+            });
+            res.on("end", function () {
+              console.log("End of data");
+            });
+          }
+        );
+      });
+      res.on("end", function () {
+        console.log("End of data on query");
+      });
+    }
+  );
+
+  req.write(
+    JSON.stringify({
+      query: query,
     })
-;
+  );
+  req.end();
+});

--- a/javascript/demo/demo.html
+++ b/javascript/demo/demo.html
@@ -1,25 +1,73 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <!--
+    To run this demo:
+      1. Build the oneseismic library in non-module mode (aka ONESEISMIC_MODULARIZE=OFF)
+      2. Copy the artifacts (oneseismic.js and oneseismic.wasm) to the demo directory
+      3. Assure correct CORS in the server config
+      4. Update server, guid and sas_token.
+         For demo purpose container must be small as there is no wait
+      5. Serve the directory (for example on localhost)
+      6. Navigate in browser to <directory>/demo.html
+      7. Open browser Console and see results
+  -->
   <script>
     var Module = {
-      onRuntimeInitialized: function() {
-          fetch("http://host:port/result/<pid>/stream", {
-              headers: {
-                  'Authorization': 'Bearer <token>'
-              }
-         })
-        .then(response => response.arrayBuffer())
-        .then(function (chunk) {
-              console.log(chunk);
-              let dec = Module.stream_decoder();
-              var x = dec(chunk);
-              x = dec(null);
-              const a = x[1]['data']['data'];
-              console.log(a.reduce((acc, v) => acc +v ));
-        })
-      }
+      onRuntimeInitialized: function () {
+        server = "<oneseismic-endpoint>";
+        guid = "<guid>";
+        sas_token = "<sas_token>";
+
+        url = `${server}/graphql?${sas_token}`;
+        const query = `{ cube (id: "${guid}") { sliceByIndex(dim: 0, index: 0) } }`;
+
+        fetch(url, {
+          method: "post",
+          headers: {
+            "Content-type": "application/json",
+          },
+          body: JSON.stringify({
+            query: query,
+          }),
+        }).then(function (response) {
+          if (!response.ok) {
+            throw new Error("Fetch failed with status " + response.statusText);
+          }
+          response
+            .json()
+            .then(function (data) {
+              return data.data.cube.sliceByIndex;
+            })
+            .then((promise) => {
+              fetch(`${server}/${promise.url}/stream`, {
+                headers: {
+                  Authorization: `Bearer ${promise.key}`,
+                },
+              })
+                .then((response) => {
+                  if (response.ok) {
+                    return response.arrayBuffer();
+                  } else {
+                    throw new Error(
+                      "Fetch failed with status " + response.statusText
+                    );
+                  }
+                })
+                .then(function (chunk) {
+                  console.log(chunk);
+                  let dec = Module.stream_decoder();
+                  var x = dec(chunk);
+                  x = dec(null);
+                  const a = x[1]["data"]["data"];
+                  console.log(a.reduce((acc, v) => acc + v));
+                });
+            });
+        });
+      },
     };
   </script>
   <script src="oneseismic.js"></script>
 </html>
-


### PR DESCRIPTION
Doing a PR now in unlikely case it's useful in the next month.

No parseopt tests at the moment.
Looks like getopt package keeps defined command line options between tests and complains when parsopt is called second time. And I can't find a way to force tests reload.
That probably means that if this is to be tested, definition of command line args and parsing of args has to be splited, but I am not exactly there yet.
Regarding demos - I don't know how they work, but at least now they both print the same value to me for the same file :smile: 