### PR TITLE
Update python gql dependency

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,6 +1,6 @@
 azure-storage-blob
 azure-identity
-gql
+gql[requests]
 hypothesis
 importlib-metadata >= '1.0'; python_version < '3.8'
 numpy


### PR DESCRIPTION
New python gql version had a breaking change which requires us to
explicitly ask for additional dependencies that we use.