### PR TITLE
Build wheels using windows-2019 runner on gh

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
+        run: python -m pip install cibuildwheel==2.3.1
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -14,12 +14,14 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macOS-10.15]
         include:
-          - os: windows-2016
+          - os: windows-2019
             cibw-arch: AMD64
-            cmake-generator: "Visual Studio 15 2017 Win64"
-          - os: windows-2016
+            cmake-generator: "Visual Studio 16 2019"
+            cmake_generator_platform: "x64"
+          - os: windows-2019
             cibw-arch: x86
-            cmake-generator: "Visual Studio 15 2017"
+            cmake-generator: "Visual Studio 16 2019"
+            cmake_generator_platform: "Win32"
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +34,10 @@ jobs:
 
       - name: Build wheels
         env:
-          CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="${{ matrix.cmake-generator }}"
+          CIBW_ENVIRONMENT_WINDOWS: >
+            CMAKE_GENERATOR="${{ matrix.cmake-generator }}"
+            CMAKE_GENERATOR_PLATFORM="${{ matrix.cmake_generator_platform }}"
+
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw-arch }}
           COMSPEC: C:\Program Files\PowerShell\7\pwsh.EXE
         run: |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,6 +18,7 @@ before-all = [
         -B msgpack-3.3.0/build \
         -DMSGPACK_CXX_ONLY=ON \
         -DMSGPACK_BUILD_EXAMPLES=OFF \
+        -DMSGPACK_BUILD_DOCS=OFF \
         -DCMAKE_INSTALL_PREFIX=core/ \
     """,
     """cmake \

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,6 @@ before-all = [
         -S msgpack-3.3.0  \
         -B msgpack-3.3.0/build \
         -DMSGPACK_CXX_ONLY=ON \
-        -DMSGPACK_BUILD_EXAMPLES=OFF \
         -DMSGPACK_BUILD_DOCS=OFF \
         -DCMAKE_INSTALL_PREFIX=core/ \
     """,


### PR DESCRIPTION
The windows-2016 environment is deprecated and was removed as of April
1st, 2022 [1]. As a result, or CI pipeline have skipped the
wheelbuilding on windows since then. Upgrading environment also
requires a bump of the MSVC version from 15 -> 16.

[1] https://github.com/actions/virtual-environments/issues/5238