### PR TITLE
Introduce a storage facade

### DIFF
--- a/api/cmd/fetch/fetch_test.go
+++ b/api/cmd/fetch/fetch_test.go
@@ -5,30 +5,11 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-	"github.com/stretchr/testify/assert"
 )
 
 func testurl() *url.URL {
 	addr, _ := url.Parse("https://example.com")
 	return addr
-}
-
-func TestCancelledDownloadErrors(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	blob, err := azblob.NewBlobClientWithNoCredential(testurl().String(), nil)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = downloadBlob(ctx, blob, &azblob.DownloadBlobOptions{})
-	if err == nil {
-		t.Errorf("expected downloadBlob() to fail; err was nil")
-	}
-
-	msg := "context canceled"
-	assert.Containsf(t, err.Error(), msg, "want err =~ '%s'; was %v", msg, err)
 }
 
 func TestCancelledDownloadPostsOnErrorChannel(t *testing.T) {

--- a/api/cmd/fetch/pipeline.go
+++ b/api/cmd/fetch/pipeline.go
@@ -5,62 +5,7 @@ import (
 	"net/url"
 
 	"github.com/equinor/oneseismic/api/internal/storage"
-
-	"github.com/dgraph-io/ristretto"
 )
-
-/*
- * This module implements a worker pool for blob fetches, with caching. The
- * intended use is for the main function to spawn a worker group that pulls
- * URLs and serves downloaded, possibly cached, blobs. The worker pool are
- * stupid pipes and have no context or reference to the task that provided the
- * URLs.
- */
-
-/*
- * Silly & minimal interface to a cache of fragments - this hides a lot of
- * features, but should make some testing and benchmarking easier by providing
- * a way to tune or disable the cache.
- *
- * It achieves two things:
- * 1. ease-of-testing through custom cache implementations
- * 2. automates the casting, forcing the cache to only store the cacheentry
- *    type, which is way less annoying than dealing with interface{}
- */
-type fragmentcache interface {
-	set(string, cacheEntry)
-	get(string) (cacheEntry, bool)
-}
-
-type cacheEntry struct {
-	chunk []byte
-	etag  *string
-}
-
-type ristrettocache struct {
-	ristretto.Cache
-}
-func (c *ristrettocache) set(key string, val cacheEntry) {
-	c.Set(key, val, 0)
-}
-func (c *ristrettocache) get(key string) (val cacheEntry, hit bool) {
-	v, hit := c.Get(key)
-	if hit {
-		val = v.(cacheEntry)
-	}
-	return
-}
-
-/*
- * The nocache isn't really used per now, but serves as a useful reference and
- * available information for tests runs or test cases that wants to disable
- * caching altogether.
- */
-type nocache struct {}
-func (c *nocache) set(key string, val cacheEntry) {}
-func (c *nocache) get(key string) (cacheEntry, bool) {
-	return cacheEntry{}, false
-}
 
 /*
  * The downloaded fragment (as it is stored in blob). The index is a key, used

--- a/api/internal/errors.go
+++ b/api/internal/errors.go
@@ -49,6 +49,11 @@ func (qe *QueryE) Error() string {
 }
 
 type NotFoundE struct {
+	msg string
+}
+
+func NotFound(msg string) *NotFoundE {
+	return &NotFoundE{ msg: msg }
 }
 
 func NewNotFoundError() *NotFoundE {
@@ -56,5 +61,5 @@ func NewNotFoundError() *NotFoundE {
 }
 
 func (nf *NotFoundE) Error() string {
-	return "Not found"
+	return nf.msg
 }

--- a/api/internal/storage/cache.go
+++ b/api/internal/storage/cache.go
@@ -56,3 +56,7 @@ func (c *noCache) set(key string, val entity) {}
 func (c *noCache) get(key string) (entity, bool) {
 	return entity{}, false
 }
+
+func NewNoCache() *noCache {
+	return &noCache{}
+}

--- a/api/internal/storage/cache.go
+++ b/api/internal/storage/cache.go
@@ -33,6 +33,19 @@ func (c *ristrettoCache) get(key string) (val entity, hit bool) {
 	return
 }
 
+func NewRistrettoCache() (*ristrettoCache, error) {
+	cache, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters: 1e7, // 100M
+		MaxCost:     10 * (1 << 30), // 1 << 30 == 1G
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ristrettoCache{Cache: *cache}, nil
+}
+
 /*
  * The nocache isn't really used per now, but serves as a useful reference and
  * available information for tests runs or test cases that wants to disable

--- a/api/internal/storage/cache.go
+++ b/api/internal/storage/cache.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"github.com/dgraph-io/ristretto"
+)
+
+/*
+ * Silly & minimal interface to a cache of fragments - this hides a lot of
+ * features, but should make some testing and benchmarking easier by providing
+ * a way to tune or disable the cache.
+ *
+ * It achieves two things:
+ * 1. ease-of-testing through custom cache implementations
+ * 2. automates the casting, forcing the cache to only store the cacheentry
+ *    type, which is way less annoying than dealing with interface{}
+ */
+type blobCache interface {
+	set(string, entity)
+	get(string) (entity, bool)
+}
+
+type ristrettoCache struct {
+	ristretto.Cache
+}
+func (c *ristrettoCache) set(key string, val entity) {
+	c.Set(key, val, 0)
+}
+func (c *ristrettoCache) get(key string) (val entity, hit bool) {
+	v, hit := c.Get(key)
+	if hit {
+		val = v.(entity)
+	}
+	return
+}
+
+/*
+ * The nocache isn't really used per now, but serves as a useful reference and
+ * available information for tests runs or test cases that wants to disable
+ * caching altogether.
+ */
+type noCache struct {}
+func (c *noCache) set(key string, val entity) {}
+func (c *noCache) get(key string) (entity, bool) {
+	return entity{}, false
+}

--- a/api/internal/storage/storage.go
+++ b/api/internal/storage/storage.go
@@ -77,6 +77,9 @@ func (c *AzStorage) Get(ctx context.Context, blob string) (*entity, error) {
 		switch status {
 		case http.StatusNotModified:
 			return &cached, nil
+		case http.StatusNotFound:
+			msg := fmt.Sprintf("Not found: %s/%s", bloburl.Host, bloburl.Path)
+			return nil, internal.NotFound(msg)
 		case http.StatusForbidden:
 			return nil, internal.PermissionDeniedFromStatus(status)
 		case http.StatusUnauthorized:

--- a/api/internal/storage/storage.go
+++ b/api/internal/storage/storage.go
@@ -1,0 +1,24 @@
+package storage
+
+import (
+	"context"
+)
+
+
+type entity struct {
+	Data []byte
+	Tag  *string
+}
+
+/*
+ *  Minimal interface for fetching blobs/files from storage. This hides a lot of
+ *  feature and details about the underlying storage from the rest of the
+ *  system, making it easy to swap out the storage provider. This means testing
+ *  becomes easier through custom storage implementations.
+ */
+type StorageClient interface {
+	/*
+	 * Get a blob or file from storage
+	 */
+	Get(ctx context.Context, blob string) (*entity, error)
+}

--- a/api/internal/storage/storage.go
+++ b/api/internal/storage/storage.go
@@ -2,13 +2,16 @@ package storage
 
 import (
 	"context"
-	"net/url"
+	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
+	"net/url"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 
 	"github.com/equinor/oneseismic/api/internal"
+	"github.com/equinor/oneseismic/api/internal/util"
 )
 
 
@@ -34,31 +37,95 @@ type StorageClient interface {
  * Azure Blob Store implementation of a oneseismic StorageClient
  */
 type AzStorage struct {
+	cache blobCache
 }
 
 func (c *AzStorage) Get(ctx context.Context, blob string) (*entity, error) {
-	_, err := url.Parse(blob)
+	bloburl, err := url.Parse(blob)
 	if err != nil {
 		log.Printf("Invalid URL: %s", blob)
 		return nil, internal.InternalError(err.Error())
 	}
 
-	client, err := azblob.NewBlobClientWithNoCredential(blob, nil)
-	if err != nil {
+	key := newCacheKey(bloburl)
+	cached, hit := c.cache.get(key)
+
+	cold, err := c.download(ctx, bloburl, cached.Tag)
+	if err == nil {
+		/* nil means the azblob.Download succeeded *and* was not etag match */
+		if hit {
+			/* This probably means expired ETag, which again means a fragment
+			* has been updated since cached. This should not happen in a
+			* healthy system and must be investigated immediately.
+			 */
+			log.Printf(
+				"ETag (= %s) expired for %v; investigate immediately",
+				*cached.Tag,
+				bloburl,
+			)
+			return nil, internal.NewInternalError()
+		} else {
+			// This is good; not in cache, so clean fetch was expected.
+			go c.cache.set(key, *cold)
+			return cold, nil
+		}
+	}
+
+	switch e := err.(type) {
+	case azblob.StorageError:
+		switch e.Response().StatusCode {
+		case http.StatusNotModified:
+			return &cached, nil
+		default:
+			// TODO: what other codes can actually show up here? Forbidden? No such
+			// resource? For now, don't leak anything back, but log and add
+			// case-by-case
+			log.Printf("Unhandled azblob.StorageError: %v", err)
+			return nil, internal.InternalError(err.Error())
+		}
+	default:
+		log.Printf("Unhandled error type %T (= %v)", e, e)
 		return nil, internal.InternalError(err.Error())
 	}
 
-	dl, err := client.Download(ctx, nil)
+	return nil, err
+}
+
+func (c *AzStorage) download(
+	ctx     context.Context,
+	bloburl *url.URL,
+	etag    *string,
+) (*entity, error) {
+	client, err := azblob.NewBlobClientWithNoCredential(bloburl.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
+	options := &azblob.DownloadBlobOptions{
+		BlobAccessConditions: &azblob.BlobAccessConditions{
+			ModifiedAccessConditions : &azblob.ModifiedAccessConditions{
+				IfNoneMatch: etag,
+			},
+		},
+	}
+
+	dl, err := client.Download(ctx, options)
+	if err != nil {
+		return nil, util.UnpackAzStorageError(err)
+	}
 	body := dl.Body(&azblob.RetryReaderOptions{})
 	defer body.Close()
 	data, err := ioutil.ReadAll(body)
 	return &entity{ Data: data, Tag: dl.ETag }, err
 }
 
-func NewAzStorage() *AzStorage {
-	return &AzStorage{}
+func NewAzStorage(cache blobCache) *AzStorage {
+	return &AzStorage{cache: cache}
+}
+
+/*
+ * Creates a cache key from the host + path
+ */
+func newCacheKey(bloburl *url.URL) string {
+	return fmt.Sprintf("%s/%s", bloburl.Host, bloburl.Path)
 }

--- a/api/internal/storage/storage.go
+++ b/api/internal/storage/storage.go
@@ -2,6 +2,13 @@ package storage
 
 import (
 	"context"
+	"net/url"
+	"io/ioutil"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+
+	"github.com/equinor/oneseismic/api/internal"
 )
 
 
@@ -21,4 +28,37 @@ type StorageClient interface {
 	 * Get a blob or file from storage
 	 */
 	Get(ctx context.Context, blob string) (*entity, error)
+}
+
+/*
+ * Azure Blob Store implementation of a oneseismic StorageClient
+ */
+type AzStorage struct {
+}
+
+func (c *AzStorage) Get(ctx context.Context, blob string) (*entity, error) {
+	_, err := url.Parse(blob)
+	if err != nil {
+		log.Printf("Invalid URL: %s", blob)
+		return nil, internal.InternalError(err.Error())
+	}
+
+	client, err := azblob.NewBlobClientWithNoCredential(blob, nil)
+	if err != nil {
+		return nil, internal.InternalError(err.Error())
+	}
+
+	dl, err := client.Download(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body := dl.Body(&azblob.RetryReaderOptions{})
+	defer body.Close()
+	data, err := ioutil.ReadAll(body)
+	return &entity{ Data: data, Tag: dl.ETag }, err
+}
+
+func NewAzStorage() *AzStorage {
+	return &AzStorage{}
 }

--- a/api/internal/storage/storage_test.go
+++ b/api/internal/storage/storage_test.go
@@ -11,7 +11,8 @@ func TestCancelledAzStorageGetErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	azstorage := NewAzStorage()
+	cache := &noCache{}
+	azstorage := NewAzStorage(cache)
 
 	_, err := azstorage.Get(ctx, "https://example.com")
 	if err == nil {

--- a/api/internal/storage/storage_test.go
+++ b/api/internal/storage/storage_test.go
@@ -11,7 +11,7 @@ func TestCancelledAzStorageGetErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	cache := &noCache{}
+	cache := NewNoCache()
 	azstorage := NewAzStorage(cache)
 
 	_, err := azstorage.Get(ctx, "https://example.com")

--- a/api/internal/storage/storage_test.go
+++ b/api/internal/storage/storage_test.go
@@ -1,0 +1,23 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCancelledAzStorageGetErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	azstorage := NewAzStorage()
+
+	_, err := azstorage.Get(ctx, "https://example.com")
+	if err == nil {
+		t.Errorf("expected Get() to fail; err was nil")
+	}
+
+	msg := "context canceled"
+	assert.Containsf(t, err.Error(), msg, "want err =~ '%s'; was %v", msg, err)
+}

--- a/api/internal/util/util.go
+++ b/api/internal/util/util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"compress/gzip"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -172,38 +171,6 @@ func UnpackAzStorageError(err error) error {
 	}
 
 	return err
-}
-
-/*
- * Get the manifest for the cube from the blob store.
- *
- * It's important that this is a blocking read, since this is the first
- * authorization mechanism in oneseismic. If the user (through the
- * on-behalf-token) does not have permissions to read the manifest, it
- * shouldn't be able to read the cube either. If so, no more processing should
- * be done, and the request discarded.
- */
-func FetchManifest(
-	ctx          context.Context,
-	containerURL *url.URL,
-) ([]byte, error) {
-	container, err := azblob.NewContainerClientWithNoCredential(
-		containerURL.String(),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	blob    := container.NewBlobClient("manifest.json")
-	dl, err := blob.Download(ctx, &azblob.DownloadBlobOptions{})
-	if err != nil {
-		return nil, UnpackAzStorageError(err)
-	}
-
-	body := dl.Body(&azblob.RetryReaderOptions{})
-	defer body.Close()
-	return ioutil.ReadAll(body)
 }
 
 /*

--- a/api/internal/util/util.go
+++ b/api/internal/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"compress/gzip"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -11,7 +10,6 @@ import (
 	"time"
 
 	"github.com/equinor/oneseismic/api/internal"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -150,27 +148,6 @@ func GraphQLQueryFromGet(query url.Values) (*GraphQLQuery, error) {
 	}
 
 	return &params, nil
-}
-
-/*
- * Automate unwrapping of azblob.StorageError
- *
- * azblob methods such as azblob.BlobClient.Download will wrap any error in
- * azblob.InternalError before returning to the caller. This is rather annoying
- * if we want to switch on error type, or in the case of azblob.StorageError, the
- * StorageErrorCode.
- *
- * This function undoes the work of azblob by attempting to unpack the wrapped
- * StorageError. If the underlying error is not a azblob.StorageError, this is
- * a no-op and the original error is returned.
- */
-func UnpackAzStorageError(err error) error {
-	var stgErr *azblob.StorageError
-	if errors.As(err, &stgErr) {
-		return *stgErr
-	}
-
-	return err
 }
 
 /*


### PR DESCRIPTION
This PR introduces a storage facade in form of a go interface which
aims to hide the details of the underlying storage (e.g. Azure
BlobStore) from the rest of the system. Caching of downloaded 
artifacts is made a part of the storage facade implementation(s).

This storage facade achieves three things:
- The interaction with storage backend(s) is centralized in a single place.
- It makes testing easier through custom storage implementations.
- Implementations can and should support optional caching.