### PR TITLE
Add an database abstraction 

### DIFF
--- a/api/catalogue/graphql.go
+++ b/api/catalogue/graphql.go
@@ -26,6 +26,7 @@ type gql struct {
 
 type dbSchema struct {
 	query          string
+	table          string
 	manifestColumn string
 	geometryColumn string
 }
@@ -60,6 +61,7 @@ func MakeDBSchema(
 
 	return &dbSchema{
 		query:          query,
+		table:          table,
 		manifestColumn: manifestColumn,
 		geometryColumn: geometryColumn,
 	}

--- a/api/catalogue/graphql.go
+++ b/api/catalogue/graphql.go
@@ -3,7 +3,6 @@ package catalogue
 import (
 	"context"
 	_ "embed"
-	"fmt"
 	"log"
 	"net/http"
 
@@ -99,25 +98,15 @@ func (r *resolver) Manifests(
 	},
 ) ([]*psql.Manifest, error) {
 	qctx := ctx.Value("queryctx").(*queryContext)
-	connpool := qctx.connpool
-	dbschema := qctx.dbschema
 
-	where := psql.Where(
+	query := psql.FilteredManifestQuery(
+		qctx.dbschema,
 		args.Where,
 		args.Intersects,
-		dbschema.Cols.Manifest,
-		dbschema.Cols.Geometry,
-	)
-
-	query := fmt.Sprintf(
-		"SELECT %s FROM %s %s LIMIT $1 OFFSET $2",
-		dbschema.Cols.Manifest,
-		dbschema.Table,
-		where,
 	)
 
 	return psql.ExecQuery(
-		connpool,
+		qctx.connpool,
 		query,
 		args.First,
 		args.Offset,

--- a/api/catalogue/graphql.go
+++ b/api/catalogue/graphql.go
@@ -40,20 +40,6 @@ func MakeGraphQL(connpool *pgxpool.Pool, dbschema *psql.Schema) *gql {
 	}
 }
 
-func MakeDBSchema(
-	table          string,
-	manifestColumn string,
-	geometryColumn string,
-) (*psql.Schema) {
-	return &psql.Schema{
-		Table: table,
-		Cols:  psql.Columns {
-			Manifest: manifestColumn,
-			Geometry: geometryColumn,
-		},
-	}
-}
-
 type queryContext struct {
 	connpool *pgxpool.Pool
 	dbschema *psql.Schema

--- a/api/catalogue/graphql.go
+++ b/api/catalogue/graphql.go
@@ -25,10 +25,14 @@ type gql struct {
 }
 
 type dbSchema struct {
-	query          string
-	table          string
-	manifestColumn string
-	geometryColumn string
+	query string
+	table string
+	cols  Columns
+}
+
+type Columns struct {
+	manifest string
+	geometry string
 }
 
 func MakeGraphQL(connpool *pgxpool.Pool, dbschema *dbSchema) *gql {
@@ -60,10 +64,12 @@ func MakeDBSchema(
 	)
 
 	return &dbSchema{
-		query:          query,
-		table:          table,
-		manifestColumn: manifestColumn,
-		geometryColumn: geometryColumn,
+		query: query,
+		table: table,
+		cols:  Columns {
+			manifest: manifestColumn,
+			geometry: geometryColumn,
+		},
 	}
 }
 
@@ -132,8 +138,8 @@ func (r *resolver) Manifests(
 	where := psql.Where(
 		args.Where,
 		args.Intersects,
-		dbschema.manifestColumn,
-		dbschema.geometryColumn,
+		dbschema.cols.manifest,
+		dbschema.cols.geometry,
 	)
 
 	query := fmt.Sprintf(dbschema.query, where)

--- a/api/catalogue/graphql.go
+++ b/api/catalogue/graphql.go
@@ -21,20 +21,10 @@ var schema string
 type gql struct {
 	schema   *graphql.Schema
 	connpool *pgxpool.Pool
-	dbschema *dbSchema
+	dbschema *psql.Schema
 }
 
-type dbSchema struct {
-	table string
-	cols  Columns
-}
-
-type Columns struct {
-	manifest string
-	geometry string
-}
-
-func MakeGraphQL(connpool *pgxpool.Pool, dbschema *dbSchema) *gql {
+func MakeGraphQL(connpool *pgxpool.Pool, dbschema *psql.Schema) *gql {
 	resolver := &resolver {}
 
 	opts := []graphql.SchemaOpt{
@@ -54,19 +44,19 @@ func MakeDBSchema(
 	table          string,
 	manifestColumn string,
 	geometryColumn string,
-) (*dbSchema) {
-	return &dbSchema{
-		table: table,
-		cols:  Columns {
-			manifest: manifestColumn,
-			geometry: geometryColumn,
+) (*psql.Schema) {
+	return &psql.Schema{
+		Table: table,
+		Cols:  psql.Columns {
+			Manifest: manifestColumn,
+			Geometry: geometryColumn,
 		},
 	}
 }
 
 type queryContext struct {
 	connpool *pgxpool.Pool
-	dbschema *dbSchema
+	dbschema *psql.Schema
 }
 
 func (g *gql) Get(ctx *gin.Context) {
@@ -129,14 +119,14 @@ func (r *resolver) Manifests(
 	where := psql.Where(
 		args.Where,
 		args.Intersects,
-		dbschema.cols.manifest,
-		dbschema.cols.geometry,
+		dbschema.Cols.Manifest,
+		dbschema.Cols.Geometry,
 	)
 
 	query := fmt.Sprintf(
 		"SELECT %s FROM %s %s LIMIT $1 OFFSET $2",
-		dbschema.cols.manifest,
-		dbschema.table,
+		dbschema.Cols.Manifest,
+		dbschema.Table,
 		where,
 	)
 

--- a/api/catalogue/graphql.go
+++ b/api/catalogue/graphql.go
@@ -25,7 +25,6 @@ type gql struct {
 }
 
 type dbSchema struct {
-	query string
 	table string
 	cols  Columns
 }
@@ -56,15 +55,7 @@ func MakeDBSchema(
 	manifestColumn string,
 	geometryColumn string,
 ) (*dbSchema) {
-	query := fmt.Sprintf(
-		"SELECT %s FROM %s %s LIMIT $1 OFFSET $2",
-		manifestColumn,
-		table,
-		"%s",
-	)
-
 	return &dbSchema{
-		query: query,
 		table: table,
 		cols:  Columns {
 			manifest: manifestColumn,
@@ -142,7 +133,12 @@ func (r *resolver) Manifests(
 		dbschema.cols.geometry,
 	)
 
-	query := fmt.Sprintf(dbschema.query, where)
+	query := fmt.Sprintf(
+		"SELECT %s FROM %s %s LIMIT $1 OFFSET $2",
+		dbschema.cols.manifest,
+		dbschema.table,
+		where,
+	)
 
 	return psql.ExecQuery(
 		connpool,

--- a/api/cmd/catalogue/main.go
+++ b/api/cmd/catalogue/main.go
@@ -93,7 +93,9 @@ func main() {
 		},
 	}
 
-	gql := catalogue.MakeGraphQL(pool, dbschema)
+	client := postgres.NewPgClient(pool, dbschema)
+
+	gql := catalogue.MakeGraphQL(client)
 
 	provider := auth.GetJwksProvider(opts.authserver)
 	tokenvalidator := auth.JWTvalidation(

--- a/api/cmd/catalogue/main.go
+++ b/api/cmd/catalogue/main.go
@@ -85,7 +85,14 @@ func main() {
 	}
 	defer pool.Close()
 
-	dbschema := catalogue.MakeDBSchema("oneseismic.catalogue", "manifest", "geometry")
+	dbschema := &postgres.Schema{
+		Table: "oneseismic.catalogue",
+		Cols: postgres.Columns {
+			Manifest: "manifest",
+			Geometry: "geometry",
+		},
+	}
+
 	gql := catalogue.MakeGraphQL(pool, dbschema)
 
 	provider := auth.GetJwksProvider(opts.authserver)

--- a/api/internal/postgres/postgres.go
+++ b/api/internal/postgres/postgres.go
@@ -13,6 +13,16 @@ import (
 	"github.com/equinor/oneseismic/api/internal"
 )
 
+type Schema struct {
+	Table string
+	Cols  Columns
+}
+
+type Columns struct {
+	Manifest string
+	Geometry string
+}
+
 type coordinate struct {
 	X float64
 	Y float64

--- a/api/internal/postgres/postgres.go
+++ b/api/internal/postgres/postgres.go
@@ -13,6 +13,20 @@ import (
 	"github.com/equinor/oneseismic/api/internal"
 )
 
+/*
+ * A catalogue specific database connection wrapper that automates the few
+ * database queries used by the oneseismic catalogue. It's defined as an
+ * interface such that it can easily be mocked in tests.
+ */
+type IndexClient interface {
+	GetManifests(
+		jsonFilter *ManifestFilter,
+		geomFilter *Geometry,
+		limit      int32,
+		offset     int32,
+	) ([]*Manifest, error)
+}
+
 type Schema struct {
 	Table string
 	Cols  Columns


### PR DESCRIPTION
This PR does a couple of refactor / prep-commits, then introduces an Index / database facade that aims to hide the database transport / connection from the rest of the system. It's implemented as a go interface to allow mocking, which will make it easier to test the rest of the system without having a real connection. 
